### PR TITLE
docs: establish contributor identity docs and add issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report something that is broken or behaving unexpectedly
+title: "bug: "
+labels: [bug]
+assignees: []
+---
+
+## Summary
+
+Describe the bug in one or two sentences.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+What should happen?
+
+## Actual behavior
+
+What happened instead?
+
+## Environment
+
+- Device:
+- Browser:
+- Route/page:
+- Logged in or anonymous:
+
+## Additional context
+
+Screenshots, logs, or related issue links.

--- a/.github/ISSUE_TEMPLATE/community_event.md
+++ b/.github/ISSUE_TEMPLATE/community_event.md
@@ -1,0 +1,28 @@
+---
+name: Community event
+about: Plan or propose a reading/community event
+title: "event: "
+labels: [community]
+assignees: []
+---
+
+## Event concept
+
+What is the event?
+
+## Goal
+
+What community outcome are we aiming for?
+
+## Format
+
+Online / offline / hybrid.
+
+## Proposed date and location
+
+- Date:
+- Location:
+
+## Needed support
+
+Volunteers, materials, promotion, or tooling.

--- a/.github/ISSUE_TEMPLATE/contributor_role.md
+++ b/.github/ISSUE_TEMPLATE/contributor_role.md
@@ -1,0 +1,27 @@
+---
+name: Contributor role request
+about: Request, assign, or review contributor role badges
+title: "role: "
+labels: [community, contributor-role]
+assignees: []
+---
+
+## User
+
+Profile username or link:
+
+## Requested role(s)
+
+- 
+
+## Reason
+
+What contribution supports this role assignment?
+
+## Evidence
+
+Issue/PR/event/profile links:
+
+## Decision notes
+
+For maintainers/admins.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Propose a new feature or improvement
+title: "feat: "
+labels: [enhancement]
+assignees: []
+---
+
+## Problem
+
+What community/user problem are we solving?
+
+## Proposed solution
+
+What should we build?
+
+## MVP scope
+
+What is the smallest useful version?
+
+## Success criteria
+
+How do we know this is useful?
+
+## Notes
+
+Dependencies, risks, or alternatives.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+What changed?
+
+## Why
+
+Why does this matter for Collective Library?
+
+## Scope
+
+- [ ] Product/code
+- [ ] Docs
+- [ ] Community process
+- [ ] Other
+
+## Test steps
+
+How can reviewers verify this safely?
+
+## Related issues
+
+Closes #
+
+## Screenshots (if UI changes)
+
+Add before/after when relevant.

--- a/README.md
+++ b/README.md
@@ -1,132 +1,102 @@
 # Collective Library
 
-> Where books connect people, and ideas turn into movement.
+> Where books connect people, and ideas become a movement.
 
-Mobile-first community book marketplace + lending network for the Journey Perintis reading community in Semarang. **Gratis selamanya. No take-rate.**
+Collective Library is a **community-driven knowledge ecosystem**.
+It helps people share books from personal shelves, discover ideas through trusted peers, and build meaningful relationships through learning.
 
-🌐 Live: [collectivelibrary.vercel.app](https://collectivelibrary.vercel.app)
-📸 Instagram: [@collectivelibrary.id](https://www.instagram.com/collectivelibrary.id)
-💬 Discord: [discord.gg/2nCu5p9Hsd](https://discord.gg/2nCu5p9Hsd)
+This is not a traditional library app. It is distributed, social, trust-based, and open-source.
+
+- 🌐 Live: [collectivelibrary.vercel.app](https://collectivelibrary.vercel.app)
+- 📸 Instagram: [@collectivelibrary.id](https://www.instagram.com/collectivelibrary.id)
+- 💬 Discord: [discord.gg/2nCu5p9Hsd](https://discord.gg/2nCu5p9Hsd)
 
 ---
 
-## What this is
+## Why this exists
 
-Books already exist on JP members' shelves. Trust already exists in the community. **They're invisible until a platform surfaces them.** Collective Library is infrastructure — not Goodreads-Indo, not Tokopedia-for-books — for a community that's already real.
+Books are already everywhere: on people’s shelves, in reading circles, and inside communities.
+What is usually missing is shared visibility and connection.
 
-Three core verbs:
+Collective Library exists to make knowledge networks visible and usable:
 
-- **Jual** — lepas buku yang udah dibaca, langsung ke pembaca lain
-- **Pinjam** — bagi buku ke anggota terpercaya, balik diskusi
-- **Tukar** — barter judul dengan teman seprogram
+- show who has what books
+- make borrowing/lending/discovery easier
+- help readers find each other
+- turn contribution into identity and trust
 
-Plus a fourth: **WTB (Wanted to Buy)** — posting cari buku, anggota yang punya langsung notif.
+---
 
-## Features
+## Who this is for
 
-| Surface | What it does |
-|---|---|
-| `/` | Public landing — books strip, activity feed, member strip, IG feed (Behold.so), founder voice |
-| `/shelf` | Collective shelf — paginated grid (24/page), filter by status, FTS-ranked search |
-| `/aktivitas` | Activity feed — event-based (USER_JOINED / BOOK_ADDED / STATUS_CHANGED / WTB_POSTED), interest filter, RSS subscribe |
-| `/anggota` | Member directory — kota → kecamatan → interest → intent → mode filter, map teaser |
-| `/peta` | Community map — Leaflet + Carto Positron, Snapchat-style avatar markers, opt-in via `show_on_map`, auto-geocoded via Nominatim or kode pos lookup |
-| `/wanted` | WTB requests — auto-fetched cover from Open Library, IG DM templated, notes always shown |
-| `/profile/[username]` | Public profile (anon-readable) — banner, currently-reading widget, 3-layer interests, share button |
-| `/admin/feedback` | Admin-only feedback inbox — gated by `profiles.is_admin`, status triage, internal notes |
-| `/api/feedback` | Anonymous feedback submission — Supabase + Discord webhook fan-out |
-| `/api/discord-webhook` | Supabase Database Webhook → Discord channel relay (auth via shared secret) |
-| `/api/postal-code/lookup` | Indonesian kode pos / kecamatan resolver via kodepos.vercel.app |
-| `/api/geocode` | Nominatim forward geocoding fallback |
-| `/feed.xml`, `/feed.json` | Public RSS 2.0 + JSON Feed 1.1 of community activity |
+- Readers who want to discover books from real people
+- Community members who want to lend, borrow, or exchange books
+- Organizers building local learning ecosystems
+- Contributors who want to grow an open-source social knowledge platform
 
-## Tech stack
+---
 
-- **Framework**: [Next.js 16.2.4](https://nextjs.org) (App Router, Turbopack, `proxy.ts` instead of `middleware.ts`)
-- **Language**: TypeScript strict mode
-- **Styles**: [Tailwind CSS v4](https://tailwindcss.com) with CSS-based `@theme` tokens (no `tailwind.config.ts`)
-- **Database / Auth / Storage**: [Supabase](https://supabase.com) (Postgres + RLS + storage + auth + realtime + database webhooks)
-- **Auth providers**: email/password, Google OAuth, Discord OAuth — all hCaptcha-protected
-- **Email**: Resend SMTP (Path C — currently single-recipient; needs custom domain to scale)
-- **Errors**: [Sentry](https://sentry.io) (server + client + edge, no-op when DSN unset)
-- **Analytics**: Vercel Analytics + custom `contact_click` event
-- **Image opt**: `next/image` with AVIF/WebP, browser-side compression (`browser-image-compression`) before upload
-- **Maps**: Leaflet + react-leaflet 5, Carto Positron tiles
-- **Animations**: lottie-react (3-dot pulse for loading states)
-- **OG images**: `next/og` runtime "edge" — landing OG card, favicon, apple-touch-icon all generated dynamically
-- **IG feed**: [Behold.so](https://behold.so) JSON feed (1h revalidate)
-- **Notifications**: Discord webhooks (community channel + feedback channel), feedback chip → `/api/feedback` → Discord embed
+## Current features (MVP+)
 
-## Project structure
+- Book shelf with filtering and search
+- Community activity feed + RSS/JSON feed
+- Member directory + map discovery
+- Wanted-to-buy requests
+- Public user profiles
+- Auth (email/password, Google, Discord)
+- Admin feedback inbox
+- Discord webhook relay for selected activities
 
-```
-app/
-  page.tsx                    Landing
-  about/, privacy/            Static pages
-  feed.xml/, feed.json/       Public RSS + JSON feeds
-  opengraph-image.tsx         Dynamic 1200×630 OG card
-  icon.tsx, apple-icon.tsx    Brand-tinted favicon + iOS icon
-  robots.ts, sitemap.ts       SEO basics
-  error.tsx, global-error.tsx 3-tier error boundaries (Sentry-instrumented)
-  api/
-    discord-webhook/          Activity log fan-out → Discord channel
-    feedback/                 Ticketing endpoint
-    geocode/                  Nominatim wrapper
-    postal-code/lookup/       kodepos.vercel.app wrapper
-  auth/{login,register,callback,logout}
-  onboarding/                 3-step + auto-join JP community
-  profile/[username]/         Public profile (anon-readable)
-  admin/                      Admin-gated dashboard
-    feedback/                 Triage inbox + status control
-  (app)/                      Auth-gated routes with TopBar+BottomNav
-    layout.tsx                Profile completeness check
-    shelf/                    Paginated catalog
-    aktivitas/                Activity feed
-    anggota/                  Member directory + filter sheet
-    peta/                     Community map (dynamic-imported Leaflet)
-    book/{add,add/bulk,import,[id],[id]/edit}
-    wanted/                   WTB feed + form
-    search/                   FTS search with empty-state suggestions
-    profile/edit/             Profile edit (location picker, banner upload, etc.)
-components/
-  ui/                         Primitives (Button, Input, PasswordInput, Avatar, ...)
-  books/                      BookCard, BookGrid, AddBookForm, BookPicker, ...
-  wanted/                     WantedCard, WantedForm, WantedCTA
-  profile/                    InterestChips (3-layer), MemberCard, LocationPicker, ShareProfileButton
-  activity/                   ActivityFeed widget + ActivityFeedList
-  layout/                     TopBar, BottomNav, AvatarMenu, PageShell, Footer
-  landing/                    RecentBooksStrip, RecentMembersStrip, RecentInstagramStrip,
-                              LoginNudgeProvider + GatedLink (modal nudge for anon clicks)
-  map/                        PetaClient, MapView (Leaflet + avatar markers + popup)
-  feedback/                   FeedbackChip (floating button + modal)
-  auth/                       LoginForm, RegisterForm, GoogleButton, DiscordButton, AuthShell
-lib/
-  supabase/{client,server,admin}.ts
-  auth.ts, books.ts, profile.ts, communities.ts, wanted.ts, activity.ts
-  contact.ts                  WhatsApp/IG DM template builders
-  format.ts, status.ts, cn.ts, url.ts
-  interests.ts                3-layer taxonomy (broad/sub/intent)
-  openlibrary.ts              Search (OL primary, Google Books fallback) + ISBN lookup
-  goodreads-csv.ts            CSV import parser
-  stats.ts                    Community stats for landing
-  socials.ts                  Single source of truth for social links
-  compress-image.ts           Browser-side WebP compression helper
-  instagram.ts                Behold.so feed fetcher
-  lottie/                     Hand-crafted Lottie JSON animations
-proxy.ts                      Session refresh + thin auth gate (no DB reads)
-instrumentation.ts            Sentry server/edge init
-instrumentation-client.ts     Sentry browser init
-supabase/migrations/          0001 → 0014 (init through feedback table)
-scripts/                      seed-nikolas, seed-novels-id, verify-seed
-docs/
-  STATE.md                    Living handoff doc — read this first
-  AUDIT.md                    Pre-launch audit notes
-  PRE-DEPLOY-CHECKLIST.md     Deprecated; superseded by migrations 0005-0007
-```
+For a complete list, see [`docs/FEATURES.md`](./docs/FEATURES.md).
 
-## Local development
+---
 
-### 1. Install
+## Upcoming features
+
+- Contributor role badges on profiles
+- Manual role assignment for admins (first MVP step)
+- Discord role mapping and sync (future phase)
+- GitHub contribution-aware badges (future phase)
+- Expanded community event workflows
+
+See:
+- [`docs/ROADMAP.md`](./docs/ROADMAP.md)
+- [`docs/features/CONTRIBUTOR_ROLES_AND_DISCORD_SYNC.md`](./docs/features/CONTRIBUTOR_ROLES_AND_DISCORD_SYNC.md)
+
+---
+
+## Contributor identity: badges + Discord roles
+
+Collective Library is building a contributor identity layer where contributions become visible trust signals.
+
+Example roles include:
+
+- Inventor
+- Builder
+- Explorer
+- Connector
+- Curator
+- Storyteller
+- Librarian
+- Contributor
+- Maintainer
+- Docs Gardener
+- Pull Request Hero
+
+MVP principle:
+
+- users can have multiple badges
+- one badge can be marked as primary for public display
+- assignment is manual first
+- Discord/GitHub sync is documented now, implemented later
+
+Read details in [`docs/DISCORD_ROLES.md`](./docs/DISCORD_ROLES.md).
+
+---
+
+## Getting started locally
+
+### 1) Install
 
 ```bash
 git clone https://github.com/Collective-Library/collective-library-v1.00.git
@@ -134,116 +104,125 @@ cd collective-library-v1.00
 npm install
 ```
 
-### 2. Environment variables
+### 2) Configure environment
 
-Create `.env.local` in the project root:
+Copy and edit environment values:
 
-```env
-# ─── REQUIRED ──────────────────────────────────────────────────────
-# App dies without these. Get from your Supabase project Settings → API.
-NEXT_PUBLIC_SUPABASE_URL=https://YOUR-PROJECT.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
-SUPABASE_SERVICE_ROLE_KEY=eyJ...
-
-# ─── OPTIONAL — features degrade gracefully when unset ─────────────
-
-# Canonical app URL (used for share links, OG tags, sitemap, geocoder UA)
-# Falls back to VERCEL_URL → localhost when unset.
-NEXT_PUBLIC_APP_URL=http://localhost:3000
-
-# Discord webhooks (3 separate purposes)
-DISCORD_COMMUNITY_WEBHOOK_URL=         # activity_log → #collective-library channel
-DISCORD_FEEDBACK_WEBHOOK_URL=          # feedback chip → #feedback channel
-DISCORD_WEBHOOK_SECRET=                # shared secret for Supabase Database Webhook auth
-
-# Sentry (server + client)
-SENTRY_DSN=
-NEXT_PUBLIC_SENTRY_DSN=
-
-# hCaptcha (auth pages — bot protection). When unset, captcha is silently disabled.
-NEXT_PUBLIC_HCAPTCHA_SITEKEY=
-
-# Behold.so Instagram feed ID (defaults to the @collectivelibrary.id production feed)
-NEXT_PUBLIC_INSTAGRAM_FEED_ID=
+```bash
+cp .env.example .env.local
 ```
 
-### 3. Database setup
+Minimum required values:
 
-Apply migrations to your Supabase project. From the Supabase Dashboard:
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
 
-1. Open **SQL Editor**
-2. For each file in `supabase/migrations/` (in order: `0001_init.sql` → `0014_feedback.sql`):
-   - Open the file
-   - Copy its contents
-   - Paste + Run in SQL Editor
+Optional services include Discord webhooks, Sentry, and hCaptcha.
 
-Alternatively, with the [Supabase CLI](https://supabase.com/docs/guides/cli):
+### 3) Database
+
+Run Supabase migrations in `supabase/migrations` (via Supabase SQL Editor or Supabase CLI).
 
 ```bash
 supabase db push
 ```
 
-After 0014 runs, bootstrap your first admin:
-
-```sql
-update public.profiles set is_admin = true where username = 'YOUR-USERNAME';
-```
-
-### 4. Run
+### 4) Start dev server
 
 ```bash
-npm run dev   # → http://localhost:3000
+npm run dev
 ```
 
-## Deployment
-
-`git push origin main` → Vercel auto-builds and deploys (~2 min). Watch the Vercel dashboard `Deployments` tab for status. Function logs are in `Logs` → filter by route (e.g. `/api/feedback`).
-
-The repo is connected to Vercel via the [Supabase Vercel integration](https://supabase.com/dashboard/project/_/settings/integrations) — Supabase env vars (URL / anon key / service role) auto-sync. Discord / Sentry / hCaptcha env vars must be set manually in Vercel `Settings → Environment Variables`.
-
-### Optional: Supabase Database Webhook → Discord activity channel
-
-If you want activity events (book added, member joined, WTB posted) to appear in your Discord channel:
-
-1. Set the 3 Discord env vars in Vercel (above)
-2. Supabase Dashboard → **Database → Webhooks → Create**:
-   - Name: `activity-discord-fanout`
-   - Table: `activity_log`
-   - Events: `INSERT`
-   - Type: HTTP Request, POST
-   - URL: `https://<your-domain>/api/discord-webhook`
-   - HTTP Header: `Authorization: Bearer <DISCORD_WEBHOOK_SECRET>`
-
-## Contributing
-
-This is a community project. Contributions welcome.
-
-- **Read [`docs/STATE.md`](./docs/STATE.md) first** — it's the living handoff doc covering brand, schema, decisions log, and active backlog
-- Branch from `main`, never commit directly
-- Open a PR with a description of what changes and why
-- Follow existing conventions: TypeScript strict, Tailwind v4, server components by default
-- Don't add new features without checking against the strategic guardrails (Naval/Thiel/Godin tests in STATE.md)
-
-## Architecture decisions
-
-A few opinionated calls made along the way:
-
-- **No internal chat ever** — WhatsApp + IG DM + Discord deep-links only. This is a feature, not a bug. We're not building Slack.
-- **Activity feed is event-based** (Postgres triggers → `activity_log` table), not app-emit. Cross-entity ordering for free, no race conditions.
-- **WhatsApp privacy via masked view** (`profiles_public`) — direct `profiles` SELECT is self-only via RLS.
-- **Image compression client-side** before Supabase upload — saves 70-90% storage, no Vercel function body limit.
-- **Search uses Postgres FTS** with `websearch_to_tsquery`, ilike fallback for partial tokens. No Algolia / Meilisearch.
-- **Map = Leaflet + OSM**, not Google Maps — no API key, no billing card.
-- **Login-nudge modal** instead of `/auth/login` bounce — Seth-Godin-style invitation when anon clicks a card.
-- **Permission-style Discord invite distribution** — footer + onboarding bonus + auth-page subtitle. No popups.
-
-See full decision log in `docs/STATE.md`.
-
-## License
-
-TBD. Currently closed-source; will probably go open-source once the codebase stabilizes. For now: don't redistribute without permission.
+Then open `http://localhost:3000`.
 
 ---
 
-Built by Cole, Initiator Journey Perintis & Collective Library.
-Reach out: [@nikolaswidad_](https://instagram.com/nikolaswidad_) on IG.
+## Contributing
+
+We welcome builders, writers, organizers, and curious learners.
+
+1. Read [`docs/PROJECT_VISION.md`](./docs/PROJECT_VISION.md)
+2. Read [`docs/CONTRIBUTING.md`](./docs/CONTRIBUTING.md)
+3. Check [`docs/ROADMAP.md`](./docs/ROADMAP.md)
+4. Open or join an issue
+5. Submit a pull request
+
+### First issue proposal
+
+**Title:** `feat: add contributor role badges and Discord role mapping`
+
+**Description:**
+
+```md
+Build a contributor badge system for Collective Library users, starting with manual admin assignment and future support for Discord role sync.
+
+This feature turns community contribution into visible identity:
+- Inventor
+- Builder
+- Explorer
+- Connector
+- Curator
+- Storyteller
+- Librarian
+- Contributor
+- Maintainer
+- Docs Gardener
+- Pull Request Hero
+
+MVP:
+- define contributor role data model
+- allow role assignment to users
+- show public badges on user profile
+- document Discord sync as future integration
+
+Future:
+- Discord OAuth
+- Discord bot role sync
+- GitHub contribution badge sync
+```
+
+---
+
+## Issues and pull requests
+
+- Use templates in `.github/ISSUE_TEMPLATE/`
+- Keep issues specific and actionable
+- In PRs, explain **what changed**, **why**, and **how to test**
+- Link related issues whenever possible
+
+Template files:
+
+- [Bug Report](./.github/ISSUE_TEMPLATE/bug_report.md)
+- [Feature Request](./.github/ISSUE_TEMPLATE/feature_request.md)
+- [Community Event](./.github/ISSUE_TEMPLATE/community_event.md)
+- [Contributor Role Request](./.github/ISSUE_TEMPLATE/contributor_role.md)
+- [Pull Request Template](./.github/PULL_REQUEST_TEMPLATE.md)
+
+---
+
+## Docs index
+
+- [`docs/PROJECT_VISION.md`](./docs/PROJECT_VISION.md)
+- [`docs/FEATURES.md`](./docs/FEATURES.md)
+- [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md)
+- [`docs/ROADMAP.md`](./docs/ROADMAP.md)
+- [`docs/CONTRIBUTING.md`](./docs/CONTRIBUTING.md)
+- [`docs/DISCORD_ROLES.md`](./docs/DISCORD_ROLES.md)
+- [`docs/features/CONTRIBUTOR_ROLES_AND_DISCORD_SYNC.md`](./docs/features/CONTRIBUTOR_ROLES_AND_DISCORD_SYNC.md)
+
+Legacy context docs:
+
+- [`docs/STATE.md`](./docs/STATE.md)
+- [`docs/AUDIT.md`](./docs/AUDIT.md)
+- [`docs/PRE-DEPLOY-CHECKLIST.md`](./docs/PRE-DEPLOY-CHECKLIST.md)
+
+---
+
+## Community links
+
+- Instagram: https://www.instagram.com/collectivelibrary.id
+- Discord: https://discord.gg/2nCu5p9Hsd
+- Web app: https://collectivelibrary.vercel.app
+
+If you care about books, ideas, and community learning, you are welcome here.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,27 @@
+# Architecture Overview
+
+## Stack summary
+
+- Next.js App Router web app
+- Supabase for auth + database + RLS
+- Tailwind CSS for UI
+- Discord webhooks for selected notifications
+
+## High-level flow
+
+1. Users authenticate and manage profiles/books
+2. Data is stored in Supabase tables with policy controls
+3. Community surfaces (shelf, activity, members, map) query and render shared data
+4. Some activity events fan out to Discord
+
+## Contributor role system (planned)
+
+Planned additions:
+
+- `contributor_roles` table
+- `user_contributor_roles` join table
+- Admin assignment UI/API
+- Profile badge rendering with a single primary badge
+
+Detailed proposal lives in:
+`docs/features/CONTRIBUTOR_ROLES_AND_DISCORD_SYNC.md`

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to Collective Library
+
+Thanks for being here. You can contribute as a coder, writer, organizer, or thoughtful tester.
+
+## Contribution paths
+
+- Product/code contributions
+- Documentation improvements
+- Bug reports and QA
+- Community and event initiatives
+- Contributor-role operations and trust moderation
+
+## Workflow
+
+1. Open an issue or pick an existing one
+2. Create a branch from `main`
+3. Make scoped changes
+4. Run checks locally
+5. Open a PR using the template
+
+## Pull request checklist
+
+- Explain problem and solution clearly
+- Keep changes scoped
+- Add/update docs when behavior changes
+- Include test steps
+- Link related issues
+
+## Communication style
+
+- Be clear and kind
+- Assume positive intent
+- Prefer practical progress over perfection
+
+## Good first contributions
+
+- Improve unclear copy in onboarding/profile pages
+- Add or refine docs in `/docs`
+- Triage open bugs with reproduction steps
+- Help define contributor-role criteria

--- a/docs/DISCORD_ROLES.md
+++ b/docs/DISCORD_ROLES.md
@@ -1,0 +1,45 @@
+# Discord Roles and Contributor Badges
+
+## Why this exists
+
+Contribution is often invisible. We want contribution to become visible identity and trust.
+
+## Role families
+
+Core/project roles:
+
+- Mastermind
+- Core Builder
+- Maintainer
+- Steward
+
+Community and contribution roles:
+
+- Inventor
+- Builder
+- Explorer
+- Connector
+- Curator
+- Storyteller
+- Librarian
+- Contributor
+- Issue Hunter
+- Pull Request Hero
+- Docs Gardener
+- Beta Tester
+
+## MVP rules
+
+- Assignment is manual by admin
+- A user can hold multiple badges
+- One badge can be marked as primary public identity
+- Roles should map to real evidence when possible
+
+## Future sync strategy
+
+- Map Discord role IDs ↔ contributor role slugs
+- Support account linking with Discord OAuth
+- Use bot or scheduled sync for updates
+- Keep manual override for moderation and edge cases
+
+See proposal: [`docs/features/CONTRIBUTOR_ROLES_AND_DISCORD_SYNC.md`](./features/CONTRIBUTOR_ROLES_AND_DISCORD_SYNC.md)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,0 +1,25 @@
+# Features
+
+## Current product capabilities
+
+- Public landing with recent books, members, and activity highlights
+- Authenticated shelf management and book posting
+- Activity feed with event-style updates
+- Member discovery with filters and map surface
+- Wanted-to-buy request flow
+- Public user profiles
+- Feedback intake for admins
+- RSS/JSON feeds for activity
+
+## Current community capabilities
+
+- Shared discovery across distributed personal libraries
+- Social proof through activity and profiles
+- Discord channel integration via webhooks
+
+## Planned capabilities
+
+- Contributor role badges on profiles
+- Trust and reputation signals tied to contribution
+- Discord role sync (future)
+- GitHub contribution sync (future)

--- a/docs/PROJECT_VISION.md
+++ b/docs/PROJECT_VISION.md
@@ -1,0 +1,25 @@
+# Project Vision
+
+## One sentence
+
+Collective Library is a distributed knowledge network where people share books, ideas, and trust.
+
+## Core beliefs
+
+- Knowledge does not need a central building.
+- Books in homes are still part of a living public collection.
+- Trust can be designed through identity and contribution.
+- Community participation is a feature, not a side effect.
+
+## What we are building
+
+1. Product: a web platform for sharing and discovering books
+2. Community: a social layer for relationships and collaboration
+3. Open source: a contributor ecosystem where people shape direction
+
+## What success looks like
+
+- More books discoverable across personal libraries
+- More cross-member collaboration and local events
+- Clearer contributor identity and recognition
+- A replicable model for communities in multiple cities

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,32 @@
+# Roadmap
+
+## Phase 1 — Solid MVP foundation (current)
+
+- Stabilize book, profile, directory, map, and wanted flows
+- Improve contributor onboarding documentation
+- Standardize issue and PR templates
+
+## Phase 2 — Contributor identity
+
+- Add contributor role model
+- Manual admin assignment flow
+- Public profile badges (multi-badge + primary badge)
+- Basic moderation notes and evidence tracking
+
+## Phase 3 — Discord integration
+
+- Define Discord role mapping strategy
+- OAuth account-linking design
+- Bot/webhook sync strategy with safeguards
+
+## Phase 4 — GitHub contribution sync
+
+- Contribution signal mapping (issues, PRs, docs)
+- Badge recommendation logic
+- Manual override and dispute flow
+
+## Phase 5 — Multi-city scaling
+
+- Community replication playbook
+- Local governance toolkit
+- Shared but decentralized data + trust standards

--- a/docs/features/CONTRIBUTOR_ROLES_AND_DISCORD_SYNC.md
+++ b/docs/features/CONTRIBUTOR_ROLES_AND_DISCORD_SYNC.md
@@ -1,0 +1,104 @@
+# Feature Proposal: Contributor Roles and Discord Sync
+
+## Status
+
+Proposed (MVP-first, low-risk rollout)
+
+## Problem
+
+Community contribution is valuable but often invisible.
+Without visible identity signals, trust and coordination grow slower.
+
+## Goal
+
+Turn contribution into visible profile identity using role badges, starting with manual assignment and evolving into Discord/GitHub-integrated signals.
+
+## MVP scope
+
+- Define contributor role data model
+- Enable manual role assignment by admins
+- Display public badges on user profiles
+- Allow one primary badge per user
+- Document (not overbuild) Discord sync path
+
+## Recommended roles
+
+- Mastermind
+- Core Builder
+- Maintainer
+- Steward
+- Inventor
+- Builder
+- Explorer
+- Connector
+- Curator
+- Storyteller
+- Librarian
+- Contributor
+- Issue Hunter
+- Pull Request Hero
+- Docs Gardener
+- Beta Tester
+
+## Suggested schema
+
+### `contributor_roles`
+
+- `id`
+- `name`
+- `slug`
+- `description`
+- `color`
+- `icon`
+- `source` (`manual | discord | github | system`)
+- `is_public`
+- `priority`
+- `created_at`
+- `updated_at`
+
+### `user_contributor_roles`
+
+- `user_id`
+- `role_id`
+- `assigned_by`
+- `assigned_at`
+- `source`
+- `evidence_url`
+- `notes`
+- `is_primary`
+
+## Product behavior
+
+- Users may have multiple roles.
+- Exactly zero-or-one role may be `is_primary = true` at any time.
+- Only public roles render on public profile.
+- Admin assignment should capture source and optional evidence.
+
+## Discord sync (future)
+
+Potential path:
+
+1. User links Discord account
+2. System maps Discord role IDs to role slugs
+3. Sync job applies adds/removals
+4. Manual override remains available
+
+## GitHub sync (future)
+
+Potential path:
+
+- Detect contribution events (PR merged, issues resolved, docs authored)
+- Suggest or auto-assign badges with review controls
+
+## Risks and mitigations
+
+- Vanity roles → require evidence + moderator notes
+- Role inflation → define role criteria and priority
+- Sync drift → periodic reconciliation + manual override
+
+## Definition of done (MVP)
+
+- Data model approved
+- Manual role assignment implemented/planned clearly
+- Public profile badge rendering implemented/planned clearly
+- Documentation published across README + docs


### PR DESCRIPTION
### Motivation

- Improve newcomer onboarding by clearly positioning Collective Library as a community-driven knowledge ecosystem and documenting contributor flows. 
- Surface the contributor role/badge idea and provide a low-risk MVP proposal for manual assignment and future Discord/GitHub sync. 
- Standardize contribution intake with issue templates and a PR template so community contributions are easier to open and triage.

### Description

- Rewrote `README.md` to emphasize mission, audience, current/upcoming features, contributor badges, and local dev setup. 
- Added documentation files: `docs/PROJECT_VISION.md`, `docs/CONTRIBUTING.md`, `docs/ROADMAP.md`, `docs/DISCORD_ROLES.md`, `docs/FEATURES.md`, `docs/ARCHITECTURE.md`, and `docs/features/CONTRIBUTOR_ROLES_AND_DISCORD_SYNC.md`. 
- Added GitHub templates in `.github/ISSUE_TEMPLATE/` (`bug_report.md`, `feature_request.md`, `community_event.md`, `contributor_role.md`) and added `.github/PULL_REQUEST_TEMPLATE.md`. 
- Committed the changes with message `docs: establish contributor identity and community documentation` to make the proposal and templates available to contributors immediately.

### Testing

- Ran `npm run lint` to check basic repo health; the command ran but the lint step failed due to pre-existing app code issues unrelated to these documentation/template-only changes. 
- Lint reported multiple problems (12 problems: 9 errors, 3 warnings) in app source files such as `app/error.tsx`, `components/books/book-picker.tsx`, `components/layout/topbar-search.tsx`, and `components/ui/input.tsx`. 
- No runtime or unit tests were added or modified as part of this PR; documentation and templates only were changed and are ready for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f80df582b4832c80c923628ba0d7c4)