### PR TITLE
feat(events): Event Management MVP (Phase 1 activation spine)

### DIFF
--- a/app/(app)/event/[id]/edit/delete-event-button.tsx
+++ b/app/(app)/event/[id]/edit/delete-event-button.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+
+export function DeleteEventButton({ eventId }: { eventId: string }) {
+  const router = useRouter();
+  const [confirming, setConfirming] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  async function performDelete() {
+    setBusy(true);
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("events")
+      .update({ is_hidden: true, status: "cancelled" })
+      .eq("id", eventId);
+
+    if (error) {
+      toast.error("Gagal batalin event: " + error.message);
+      setBusy(false);
+      return;
+    }
+    toast.success("Event dibatalkan.");
+    router.replace("/event");
+    router.refresh();
+  }
+
+  if (!confirming) {
+    return (
+      <Button variant="secondary" onClick={() => setConfirming(true)}>
+        Batalin event ini
+      </Button>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 p-4 rounded-card border border-red-200 bg-red-50">
+      <p className="text-body-sm text-red-700 font-medium">
+        Yakin batalin event ini? Tindakan ini tidak bisa di-undo dari UI.
+      </p>
+      <div className="flex gap-2">
+        <Button
+          variant="secondary"
+          onClick={() => setConfirming(false)}
+          disabled={busy}
+          className="flex-1"
+        >
+          Nggak jadi
+        </Button>
+        <Button
+          onClick={performDelete}
+          disabled={busy}
+          className="flex-1 !bg-red-700 hover:!bg-red-800"
+        >
+          {busy ? "Membatalkan..." : "Ya, batalin"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/event/[id]/edit/page.tsx
+++ b/app/(app)/event/[id]/edit/page.tsx
@@ -1,0 +1,46 @@
+import { notFound, redirect } from "next/navigation";
+import { getCurrentUser } from "@/lib/auth";
+import { getRawEvent } from "@/lib/events";
+import { EventForm } from "@/components/events/event-form";
+import { DeleteEventButton } from "./delete-event-button";
+
+export const dynamic = "force-dynamic";
+
+export default async function EditEventPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const user = await getCurrentUser();
+  if (!user) redirect(`/auth/login?next=/event/${id}/edit`);
+
+  const event = await getRawEvent(id);
+  if (!event) notFound();
+  if (event.host_id !== user.id) notFound();
+
+  return (
+    <div className="max-w-2xl mx-auto flex flex-col gap-6">
+      <div>
+        <p className="text-caption text-muted uppercase tracking-wide font-semibold">
+          Edit event
+        </p>
+        <h1 className="mt-1 font-display text-display-xl text-ink leading-tight">
+          {event.title}
+        </h1>
+      </div>
+
+      <EventForm userId={user.id} mode="edit" initial={event} />
+
+      <div className="mt-8 pt-6 border-t border-hairline">
+        <p className="text-caption text-muted uppercase tracking-wide font-semibold mb-2">
+          Danger zone
+        </p>
+        <p className="text-body-sm text-ink-soft mb-3">
+          Batalin event akan hide event dari feed dan mark status sebagai cancelled. RSVP list tetap tersimpan.
+        </p>
+        <DeleteEventButton eventId={event.id} />
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/event/[id]/page.tsx
+++ b/app/(app)/event/[id]/page.tsx
@@ -1,0 +1,167 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import Image from "next/image";
+import type { Metadata } from "next";
+import { getEvent, listEventRsvps } from "@/lib/events";
+import { getCurrentUser } from "@/lib/auth";
+import { formatEventWhen } from "@/lib/format";
+import { EventDetailTabs } from "@/components/events/event-detail-tabs";
+import { RsvpButton } from "@/components/events/rsvp-button";
+import { DiscordAnnounceButton } from "@/components/events/discord-announce-button";
+import { CommunityBadge } from "@/components/ui/community-badge";
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const event = await getEvent(id);
+  if (!event) return { title: "Event gak ditemukan" };
+
+  const when = formatEventWhen(event.starts_at, event.ends_at, event.timezone);
+  const host = event.host.full_name ?? event.host.username ?? "anggota";
+  const where = event.is_online ? "online" : event.location_text ?? "Semarang";
+  const description = `${event.title} — ${when} di ${where}. Host: ${host}.`;
+
+  return {
+    title: event.title,
+    description,
+    openGraph: {
+      title: event.title,
+      description,
+      type: "article",
+      images: event.cover_url ? [{ url: event.cover_url }] : undefined,
+    },
+  };
+}
+
+export default async function EventDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const [user, eventEarly] = await Promise.all([getCurrentUser(), getEvent(id)]);
+  if (!eventEarly) notFound();
+
+  // Re-fetch event with viewer's RSVP state if authed
+  const event = user ? await getEvent(id, user.id) : eventEarly;
+  if (!event) notFound();
+
+  const rsvps = await listEventRsvps(id);
+  const isHost = user?.id === event.host_id;
+  const when = formatEventWhen(event.starts_at, event.ends_at, event.timezone);
+  const hostName = event.host.full_name ?? event.host.username ?? "anggota";
+
+  return (
+    <article className="max-w-4xl mx-auto">
+      {/* ── Hero ── */}
+      <div className="relative -mx-4 md:-mx-6 mb-3 md:mb-8 overflow-hidden rounded-none md:rounded-card-lg">
+        <div className="relative aspect-video md:aspect-[21/9] bg-cream">
+          {event.cover_url ? (
+            <Image
+              src={event.cover_url}
+              alt={event.title}
+              fill
+              sizes="100vw"
+              className="object-cover"
+              priority
+            />
+          ) : (
+            <div className="absolute inset-0 bg-gradient-to-br from-cream to-parchment flex items-center justify-center p-6">
+              <p className="font-display text-display-md md:text-display-xl text-ink line-clamp-3 text-center">
+                {event.title}
+              </p>
+            </div>
+          )}
+          <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-parchment/90" />
+        </div>
+
+        <div className="relative -mt-20 px-4 md:px-6 flex flex-col gap-2">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="inline-flex items-center px-2.5 py-1 rounded-pill bg-ink text-parchment text-caption font-semibold">
+              {when}
+            </span>
+            {event.is_online && (
+              <span className="inline-flex items-center px-2.5 py-1 rounded-pill bg-paper text-ink border border-hairline-strong text-caption font-semibold">
+                Online
+              </span>
+            )}
+            {event.status === "cancelled" && (
+              <span className="inline-flex items-center px-2.5 py-1 rounded-pill bg-red-50 text-red-700 border border-red-200 text-caption font-semibold">
+                Dibatalkan
+              </span>
+            )}
+            {event.community && <CommunityBadge name={event.community.name} />}
+            {isHost && (
+              <Link
+                href={`/event/${event.id}/edit`}
+                className="ml-auto inline-flex items-center h-7 px-2.5 rounded-pill bg-paper text-ink-soft border border-hairline-strong text-caption font-medium hover:bg-cream"
+              >
+                ✎ Edit
+              </Link>
+            )}
+          </div>
+          <h1 className="font-display text-display-md md:text-display-xl text-ink leading-tight">
+            {event.title}
+          </h1>
+          <p className="text-body text-ink-soft">
+            di-host oleh{" "}
+            {event.host.username ? (
+              <Link
+                href={`/profile/${event.host.username}`}
+                className="text-ink font-medium underline underline-offset-4 hover:text-ink-soft"
+              >
+                {hostName}
+              </Link>
+            ) : (
+              <span className="text-ink font-medium">{hostName}</span>
+            )}
+          </p>
+        </div>
+      </div>
+
+      {/* ── Two-column grid ── */}
+      <div className="grid md:grid-cols-[1fr_320px] gap-5 md:gap-8">
+        <div className="min-w-0">
+          <EventDetailTabs event={event} rsvps={rsvps} isHost={isHost} />
+        </div>
+
+        <aside className="order-first md:order-none md:sticky md:top-20 md:self-start">
+          <div className="p-4 md:p-5 rounded-card-lg border border-hairline bg-paper shadow-card flex flex-col gap-3">
+            {event.status === "scheduled" ? (
+              <>
+                <RsvpButton
+                  eventId={event.id}
+                  initialStatus={event.viewer_rsvp}
+                  isAuthed={Boolean(user)}
+                />
+                <p className="text-caption text-muted text-center leading-relaxed">
+                  {event.rsvp_count > 0
+                    ? `${event.rsvp_count} udah RSVP. ${event.capacity ? `Kapasitas ${event.capacity}.` : "Belum ada batas."}`
+                    : "Lo bisa jadi yang pertama RSVP. Nggak nge-bind."}
+                </p>
+                {isHost && (
+                  <>
+                    <hr className="border-hairline" />
+                    <DiscordAnnounceButton
+                      eventId={event.id}
+                      discordAnnouncedAt={event.discord_announced_at}
+                    />
+                  </>
+                )}
+              </>
+            ) : (
+              <p className="text-body-sm text-ink-soft text-center py-2 leading-relaxed">
+                Event ini {event.status === "cancelled" ? "dibatalkan" : "sudah selesai"}.
+              </p>
+            )}
+          </div>
+        </aside>
+      </div>
+    </article>
+  );
+}

--- a/app/(app)/event/new/page.tsx
+++ b/app/(app)/event/new/page.tsx
@@ -1,0 +1,28 @@
+import { redirect } from "next/navigation";
+import { getCurrentUser } from "@/lib/auth";
+import { EventForm } from "@/components/events/event-form";
+
+export const dynamic = "force-dynamic";
+
+export default async function NewEventPage() {
+  const user = await getCurrentUser();
+  if (!user) redirect("/auth/login?next=/event/new");
+
+  return (
+    <div className="max-w-2xl mx-auto flex flex-col gap-6">
+      <div>
+        <p className="text-caption text-muted uppercase tracking-wide font-semibold">
+          Bikin event
+        </p>
+        <h1 className="mt-1 font-display text-display-xl text-ink leading-tight">
+          Ngumpul yuk
+        </h1>
+        <p className="mt-2 text-body text-ink-soft">
+          Diskusi buku, kopdar, workshop — apa aja yang bikin orang ketemu offline (atau online).
+        </p>
+      </div>
+
+      <EventForm userId={user.id} mode="create" />
+    </div>
+  );
+}

--- a/app/(app)/event/page.tsx
+++ b/app/(app)/event/page.tsx
@@ -1,0 +1,107 @@
+import Link from "next/link";
+import { listEvents } from "@/lib/events";
+import { EventCard } from "@/components/events/event-card";
+import { ButtonLink } from "@/components/ui/button";
+import { cn } from "@/lib/cn";
+
+export const dynamic = "force-dynamic";
+
+type SP = { filter?: "upcoming" | "past" };
+
+export default async function EventListPage({
+  searchParams,
+}: {
+  searchParams: Promise<SP>;
+}) {
+  const { filter } = await searchParams;
+  const activeFilter = filter === "past" ? "past" : "upcoming";
+
+  const { events, total } = await listEvents({
+    filter: activeFilter,
+    pageSize: 30,
+  });
+
+  return (
+    <div className="max-w-5xl mx-auto flex flex-col gap-6">
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <div>
+          <p className="text-caption text-muted uppercase tracking-wide font-semibold">
+            Event komunitas
+          </p>
+          <h1 className="mt-1 font-display text-display-xl text-ink leading-tight">
+            {activeFilter === "upcoming" ? "Yang akan datang" : "Yang sudah lewat"}
+          </h1>
+          <p className="mt-2 text-body text-ink-soft max-w-xl">
+            Diskusi buku, kopdar, workshop, dan kumpul-kumpul lainnya yang dibikin sama anggota.
+          </p>
+        </div>
+        <ButtonLink href="/event/new" className="shrink-0">
+          + Bikin event
+        </ButtonLink>
+      </div>
+
+      {/* Upcoming / Past filter pills */}
+      <div className="flex gap-2">
+        <FilterPill href="/event" active={activeFilter === "upcoming"} label="Akan datang" />
+        <FilterPill href="/event?filter=past" active={activeFilter === "past"} label="Yang lewat" />
+      </div>
+
+      {events.length === 0 ? (
+        <div className="rounded-card-lg border border-hairline bg-paper p-10 text-center">
+          <p className="font-display text-title-lg text-ink">
+            {activeFilter === "upcoming"
+              ? "Belum ada event yang akan datang."
+              : "Belum ada event yang sudah lewat."}
+          </p>
+          <p className="mt-2 text-body text-muted">
+            {activeFilter === "upcoming"
+              ? "Anggota belum bikin event. Lo bisa jadi yang pertama →"
+              : "Cek tab 'Akan datang' untuk yang masih bisa di-RSVP."}
+          </p>
+          {activeFilter === "upcoming" && (
+            <div className="mt-4">
+              <ButtonLink href="/event/new" variant="secondary">
+                Bikin event pertama
+              </ButtonLink>
+            </div>
+          )}
+        </div>
+      ) : (
+        <>
+          <p className="text-caption text-muted">
+            {total} event {activeFilter === "upcoming" ? "akan datang" : "sudah lewat"}
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+            {events.map((ev) => (
+              <EventCard key={ev.id} event={ev} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function FilterPill({
+  href,
+  active,
+  label,
+}: {
+  href: string;
+  active: boolean;
+  label: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "inline-flex items-center h-9 px-4 rounded-pill text-body-sm font-medium transition-colors",
+        active
+          ? "bg-ink text-parchment"
+          : "bg-paper text-ink-soft border border-hairline hover:bg-cream",
+      )}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/app/(app)/shelf/page.tsx
+++ b/app/(app)/shelf/page.tsx
@@ -2,9 +2,11 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { listShelfBooks, getShelfCounts } from "@/lib/books";
 import { listActivity } from "@/lib/activity";
+import { getUpcomingEvents } from "@/lib/events";
 import { BookGrid } from "@/components/books/book-grid";
 import { ShelfClientWrapper } from "@/components/books/shelf-client-wrapper";
 import { ActivityFeed } from "@/components/activity/activity-feed";
+import { EventCard } from "@/components/events/event-card";
 import { ButtonLink } from "@/components/ui/button";
 import { STATUS_FILTER_OPTIONS } from "@/lib/status";
 import type { BookStatus } from "@/types";
@@ -26,12 +28,14 @@ export default async function ShelfPage({ searchParams }: { searchParams: Promis
   const filter = (STATUS_FILTER_OPTIONS.find((o) => o.value === status)?.value ?? "all") as BookStatus | "all";
   const page = Math.max(1, parseInt(pageStr ?? "1", 10) || 1);
 
-  const [{ books, total }, counts, activity] = await Promise.all([
+  const showSidePanels = filter === "all" && !q && page === 1;
+  const [{ books, total }, counts, activity, upcomingEvents] = await Promise.all([
     listShelfBooks({ status: filter, search: q, page, pageSize: PAGE_SIZE }),
     getShelfCounts(),
-    // Activity widget only on the unfiltered "all" view, page 1 — keeps the
-    // filtered browsing experience clean.
-    filter === "all" && !q && page === 1 ? listActivity(4) : Promise.resolve([]),
+    // Activity widget + events strip only on the unfiltered "all" view, page 1
+    // — keeps the filtered browsing experience clean.
+    showSidePanels ? listActivity(4) : Promise.resolve([]),
+    showSidePanels ? getUpcomingEvents(4) : Promise.resolve([]),
   ]);
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
@@ -53,6 +57,28 @@ export default async function ShelfPage({ searchParams }: { searchParams: Promis
           <ButtonLink href="/book/add">+ Tambah Buku</ButtonLink>
         </div>
       </div>
+
+      {/* Upcoming events — only on the default unfiltered view */}
+      {upcomingEvents.length > 0 && (
+        <section aria-label="Event komunitas yang akan datang">
+          <div className="flex items-end justify-between gap-3 mb-3">
+            <h2 className="font-display text-title-lg text-ink leading-tight">
+              Event yang akan datang
+            </h2>
+            <Link
+              href="/event"
+              className="shrink-0 text-body-sm font-medium text-ink-soft hover:text-ink underline underline-offset-4"
+            >
+              Lihat semua →
+            </Link>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {upcomingEvents.map((ev) => (
+              <EventCard key={ev.id} event={ev} />
+            ))}
+          </div>
+        </section>
+      )}
 
       {/* Activity feed — only on the default unfiltered view */}
       {activity.length > 0 && <ActivityFeed items={activity} />}

--- a/app/api/events/[id]/announce/route.ts
+++ b/app/api/events/[id]/announce/route.ts
@@ -1,0 +1,132 @@
+// =============================================================================
+// /api/events/[id]/announce — host-only Discord embed for an event
+//
+// Mirrors /api/feedback pattern: source of truth stays in Supabase
+// (events.discord_announced_at), Discord webhook is a notification surface
+// only. Idempotent on the UI side via discord_announced_at timestamp.
+// =============================================================================
+
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getAppUrl } from "@/lib/url";
+import { getRawEvent } from "@/lib/events";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: eventId } = await params;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const event = await getRawEvent(eventId);
+  if (!event) return NextResponse.json({ error: "Event not found" }, { status: 404 });
+  if (event.host_id !== user.id) {
+    return NextResponse.json({ error: "Only the host can announce." }, { status: 403 });
+  }
+
+  // Pull host display info
+  const { data: host } = await supabase
+    .from("profiles_public")
+    .select("full_name, username")
+    .eq("id", event.host_id)
+    .maybeSingle();
+  const hostDisplay =
+    (host?.full_name as string | null) ?? (host?.username as string | null) ?? "Anggota";
+  const hostHandle = (host?.username as string | null) ?? null;
+
+  const webhookUrl =
+    process.env.DISCORD_EVENTS_WEBHOOK_URL ??
+    process.env.DISCORD_FEEDBACK_WEBHOOK_URL;
+
+  if (!webhookUrl) {
+    console.warn("[events.announce] no Discord webhook configured");
+    return NextResponse.json({ ok: true, discord: false });
+  }
+
+  const eventUrl = `${getAppUrl()}/event/${event.id}`;
+  const whenIso = event.starts_at;
+  const whenLabel = new Date(whenIso).toLocaleString("id-ID", {
+    timeZone: event.timezone || "Asia/Jakarta",
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const whereLabel = event.is_online
+    ? `Online${event.location_url ? ` — ${event.location_url}` : ""}`
+    : event.location_text ?? "TBD";
+
+  const fields: Array<{ name: string; value: string; inline?: boolean }> = [
+    { name: "Kapan", value: whenLabel, inline: true },
+    { name: "Di mana", value: whereLabel.slice(0, 200), inline: true },
+    {
+      name: "Host",
+      value: hostHandle ? `${hostDisplay} (@${hostHandle})` : hostDisplay,
+      inline: false,
+    },
+    { name: "RSVP", value: `[Buka event di Collective Library](${eventUrl})`, inline: false },
+  ];
+
+  const description = event.description
+    ? event.description.length > 1500
+      ? event.description.slice(0, 1500) + "…"
+      : event.description
+    : "Klik RSVP buat detail lengkap.";
+
+  const embed = {
+    title: `📅 ${event.title}`,
+    description,
+    color: 0x4338ca,
+    url: eventUrl,
+    fields,
+    timestamp: whenIso,
+    footer: { text: "Collective Library · events" },
+    ...(event.cover_url ? { image: { url: event.cover_url } } : {}),
+  };
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ embeds: [embed] }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.warn(
+        "[events.announce] discord webhook failed",
+        res.status,
+        text.slice(0, 200),
+      );
+      return NextResponse.json({ ok: true, discord: false });
+    }
+  } catch (err) {
+    console.warn(
+      "[events.announce] discord fetch error",
+      err instanceof Error ? err.message : err,
+    );
+    return NextResponse.json({ ok: true, discord: false });
+  }
+
+  // Bump idempotency timestamp. Host owns the row so anon-key RLS allows this.
+  const announcedAt = new Date().toISOString();
+  const { error: updateErr } = await supabase
+    .from("events")
+    .update({ discord_announced_at: announcedAt })
+    .eq("id", event.id);
+
+  if (updateErr) {
+    console.warn("[events.announce] timestamp update failed", updateErr);
+  }
+
+  return NextResponse.json({ ok: true, discord: true, announcedAt });
+}

--- a/app/api/events/[id]/rsvp/route.ts
+++ b/app/api/events/[id]/rsvp/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { cancelRsvp, rsvpEvent } from "@/lib/events";
+import type { EventRsvpStatus } from "@/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const VALID_STATUSES = new Set<EventRsvpStatus>(["going", "maybe", "declined"]);
+
+interface Body {
+  status: EventRsvpStatus | null;
+  note?: string | null;
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: eventId } = await params;
+
+  let body: Body;
+  try {
+    body = (await req.json()) as Body;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  if (body.status === null) {
+    const result = await cancelRsvp(eventId, user.id);
+    if ("error" in result) {
+      return NextResponse.json({ error: result.error }, { status: 500 });
+    }
+    return NextResponse.json({ ok: true, status: null });
+  }
+
+  if (!VALID_STATUSES.has(body.status)) {
+    return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+  }
+
+  const note = body.note?.trim().slice(0, 280) ?? undefined;
+  const result = await rsvpEvent(eventId, user.id, body.status, note);
+  if ("error" in result) {
+    return NextResponse.json({ error: result.error }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true, status: body.status });
+}

--- a/app/feed.json/route.ts
+++ b/app/feed.json/route.ts
@@ -40,12 +40,22 @@ function itemToJson(item: ActivityItem, base: string) {
 
   let url = `${base}/aktivitas`;
   if (item.book?.id) url = `${base}/book/${item.book.id}`;
+  else if (item.event?.id) url = `${base}/event/${item.event.id}`;
   else if (item.type === "WTB_POSTED") url = `${base}/wanted`;
   else if (item.type === "USER_JOINED" && item.actor?.username)
     url = `${base}/profile/${item.actor.username}`;
 
   const summaryParts: string[] = [];
   if (item.book) summaryParts.push(`${item.book.title} — ${item.book.author}`);
+  if (item.event) {
+    const whenLabel = new Date(item.event.starts_at).toLocaleDateString("id-ID", {
+      weekday: "short",
+      day: "numeric",
+      month: "short",
+      timeZone: "Asia/Jakarta",
+    });
+    summaryParts.push(`${item.event.title} — ${whenLabel}`);
+  }
   if (item.wanted)
     summaryParts.push(
       `${item.wanted.title}${item.wanted.author ? ` — ${item.wanted.author}` : ""}`,
@@ -57,7 +67,7 @@ function itemToJson(item: ActivityItem, base: string) {
     url,
     title,
     summary,
-    image: item.book?.cover_url ?? undefined,
+    image: item.book?.cover_url ?? item.event?.cover_url ?? undefined,
     date_published: new Date(item.created_at).toISOString(),
     authors: item.actor
       ? [

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -64,6 +64,7 @@ function renderItem(item: ActivityItem, base: string): string {
   // Best-effort permalink
   let link = `${base}/aktivitas`;
   if (item.book?.id) link = `${base}/book/${item.book.id}`;
+  else if (item.event?.id) link = `${base}/event/${item.event.id}`;
   else if (item.type === "WTB_POSTED") link = `${base}/wanted`;
   else if (item.type === "USER_JOINED" && item.actor?.username)
     link = `${base}/profile/${item.actor.username}`;
@@ -73,6 +74,16 @@ function renderItem(item: ActivityItem, base: string): string {
   if (item.book) {
     descParts.push(`📖 ${item.book.title} — ${item.book.author}`);
   }
+  if (item.event) {
+    const whenLabel = new Date(item.event.starts_at).toLocaleDateString("id-ID", {
+      weekday: "short",
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+      timeZone: "Asia/Jakarta",
+    });
+    descParts.push(`📅 ${item.event.title} — ${whenLabel}`);
+  }
   if (item.wanted) {
     descParts.push(`🔍 ${item.wanted.title}${item.wanted.author ? ` — ${item.wanted.author}` : ""}`);
   }
@@ -81,7 +92,7 @@ function renderItem(item: ActivityItem, base: string): string {
   }
   const description = descParts.join("\n");
 
-  const cover = item.book?.cover_url;
+  const cover = item.book?.cover_url ?? item.event?.cover_url ?? null;
   const enclosure = cover
     ? `\n      <enclosure url="${escapeXml(cover)}" type="image/jpeg" length="0" />\n      <media:thumbnail url="${escapeXml(cover)}" />`
     : "";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { ActivityFeed } from "@/components/activity/activity-feed";
 import { RecentBooksStrip } from "@/components/landing/recent-books-strip";
 import { RecentMembersStrip } from "@/components/landing/recent-members-strip";
 import { RecentInstagramStrip } from "@/components/landing/recent-instagram-strip";
+import { UpcomingEventsStrip } from "@/components/landing/upcoming-events-strip";
 import { LoginNudgeProvider } from "@/components/landing/login-nudge";
 import { GatedLink } from "@/components/landing/gated-link";
 import { getCurrentUser } from "@/lib/auth";
@@ -103,6 +104,9 @@ export default async function HomePage() {
 
         {/* Recent books — horizontal scroll strip */}
         <RecentBooksStrip />
+
+        {/* Upcoming events — horizontal scroll strip (returns null if 0) */}
+        <UpcomingEventsStrip />
 
         {/* Recent activity — peek at what's happening */}
         {activity.length > 0 && (

--- a/components/activity/activity-copy.ts
+++ b/components/activity/activity-copy.ts
@@ -43,6 +43,14 @@ export function activityVerb(item: ActivityItem | GroupedActivityItem): { text: 
       const title = item.wanted?.title ?? "buku";
       return { text: `cari buku: ${title}` };
     }
+    case "EVENT_CREATED": {
+      const title = item.event?.title ?? "event baru";
+      return { text: `bikin event: ${title}` };
+    }
+    case "EVENT_RSVPED": {
+      const title = item.event?.title ?? "event";
+      return { text: `bakal dateng ke: ${title}` };
+    }
     default:
       return { text: "ada aktivitas baru" };
   }
@@ -56,6 +64,12 @@ export function activityTargetUrl(item: ActivityItem | GroupedActivityItem): str
   }
   if (item.type === "WTB_POSTED") {
     return "/wanted";
+  }
+  if (
+    item.event?.id &&
+    (item.type === "EVENT_CREATED" || item.type === "EVENT_RSVPED")
+  ) {
+    return `/event/${item.event.id}`;
   }
   if (item.type === "USER_JOINED" && item.actor?.username) {
     return `/profile/${item.actor.username}`;

--- a/components/activity/activity-feed-list.tsx
+++ b/components/activity/activity-feed-list.tsx
@@ -157,7 +157,43 @@ function ActivityRow({ item }: { item: GroupedActivityItem }) {
         </div>
       )}
 
-      {item.wanted && !item.book && !item.is_grouped && (
+      {item.event && !item.book && !item.is_grouped && (
+        <Link
+          href={targetHref ?? `/event/${item.event.id}`}
+          className="flex gap-3 -m-1 p-3 rounded-card border border-hairline hover:bg-cream transition-colors"
+        >
+          {item.event.cover_url && (
+            <div className="relative w-20 aspect-video shrink-0 rounded-card overflow-hidden bg-cream border border-hairline">
+              <Image
+                src={item.event.cover_url}
+                alt={item.event.title}
+                fill
+                sizes="80px"
+                className="object-cover"
+                loading="lazy"
+              />
+            </div>
+          )}
+          <div className="min-w-0 flex-1 flex flex-col justify-center">
+            <p className="text-caption text-muted uppercase tracking-wide font-semibold mb-0.5">
+              Event
+            </p>
+            <p className="font-display text-title-md text-ink leading-tight line-clamp-2">
+              {item.event.title}
+            </p>
+            <p className="mt-1 text-body-sm text-muted">
+              {new Date(item.event.starts_at).toLocaleDateString("id-ID", {
+                weekday: "short",
+                day: "numeric",
+                month: "short",
+                timeZone: "Asia/Jakarta",
+              })}
+            </p>
+          </div>
+        </Link>
+      )}
+
+      {item.wanted && !item.book && !item.is_grouped && !item.event && (
         <Link
           href={targetHref ?? "/wanted"}
           className="block -m-1 p-3 rounded-card border border-hairline-strong border-dashed hover:bg-cream transition-colors"

--- a/components/events/discord-announce-button.tsx
+++ b/components/events/discord-announce-button.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { formatRelativeID } from "@/lib/format";
+
+interface Props {
+  eventId: string;
+  discordAnnouncedAt: string | null;
+}
+
+export function DiscordAnnounceButton({ eventId, discordAnnouncedAt }: Props) {
+  const [announcedAt, setAnnouncedAt] = useState(discordAnnouncedAt);
+  const [busy, setBusy] = useState(false);
+
+  async function announce() {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/events/${eventId}/announce`, { method: "POST" });
+      const json = (await res.json()) as { ok?: boolean; discord?: boolean; announcedAt?: string; error?: string };
+
+      if (!res.ok || !json.ok) {
+        toast.error(json.error ?? "Gagal kirim ke Discord.");
+        return;
+      }
+      if (json.discord === false) {
+        toast.warning("Event disimpan tapi Discord webhook belum dikonfigurasi.");
+      } else {
+        toast.success("Event diumumkan ke Discord! 📣");
+      }
+      if (json.announcedAt) setAnnouncedAt(json.announcedAt);
+    } catch {
+      toast.error("Koneksi gagal. Coba lagi.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Button variant="secondary" onClick={announce} disabled={busy} className="w-full">
+        {busy ? "Mengirim..." : "📣 Umumkan ke Discord"}
+      </Button>
+      {announcedAt && (
+        <p className="text-caption text-muted text-center">
+          Diumumkan {formatRelativeID(announcedAt)} — klik untuk umumkan lagi
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/events/event-card.tsx
+++ b/components/events/event-card.tsx
@@ -1,0 +1,80 @@
+import Link from "next/link";
+import Image from "next/image";
+import { Avatar } from "@/components/ui/avatar";
+import { formatEventWhen } from "@/lib/format";
+import type { EventWithHost } from "@/types";
+
+export function EventCard({ event }: { event: EventWithHost }) {
+  const when = formatEventWhen(event.starts_at, event.ends_at, event.timezone);
+
+  return (
+    <Link
+      href={`/event/${event.id}`}
+      className="group flex flex-col gap-3 focus-visible:outline-none"
+    >
+      {/* Cover plate — 16:9 ratio */}
+      <div className="relative aspect-video rounded-card overflow-hidden bg-cream border border-hairline group-hover:shadow-card-hover transition-shadow">
+        {event.cover_url ? (
+          <Image
+            src={event.cover_url}
+            alt={event.title}
+            fill
+            sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 300px"
+            className="object-cover"
+          />
+        ) : (
+          <EventCoverPlaceholder title={event.title} />
+        )}
+
+        {event.is_online && (
+          <span className="absolute top-2.5 left-2.5 px-2 py-0.5 rounded-full bg-ink/70 text-paper text-caption font-semibold backdrop-blur-sm">
+            Online
+          </span>
+        )}
+
+        {event.status !== "scheduled" && (
+          <span className="absolute top-2.5 right-2.5 px-2 py-0.5 rounded-full bg-ink/70 text-paper text-caption font-semibold capitalize backdrop-blur-sm">
+            {event.status === "cancelled" ? "Dibatalkan" : "Selesai"}
+          </span>
+        )}
+      </div>
+
+      {/* Meta block */}
+      <div className="flex flex-col gap-1.5">
+        <p className="text-caption text-muted font-medium leading-tight">{when}</p>
+
+        <h3 className="text-title-sm font-semibold text-ink line-clamp-2 leading-snug">
+          {event.title}
+        </h3>
+
+        {event.location_text && !event.is_online && (
+          <p className="text-caption text-muted line-clamp-1">{event.location_text}</p>
+        )}
+
+        <div className="flex items-center justify-between gap-2 mt-1">
+          <span className="flex items-center gap-1.5 min-w-0">
+            <Avatar src={event.host.photo_url} name={event.host.full_name} size={20} />
+            <span className="text-caption text-ink-soft truncate">
+              {event.host.full_name ?? event.host.username}
+            </span>
+          </span>
+          {event.rsvp_count > 0 && (
+            <span className="text-caption text-muted shrink-0">
+              {event.rsvp_count} hadir
+            </span>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function EventCoverPlaceholder({ title }: { title: string }) {
+  return (
+    <div className="w-full h-full flex items-center justify-center p-6 bg-gradient-to-br from-cream to-parchment">
+      <p className="font-display text-title-md text-ink line-clamp-3 text-center leading-tight">
+        {title}
+      </p>
+    </div>
+  );
+}

--- a/components/events/event-detail-tabs.tsx
+++ b/components/events/event-detail-tabs.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Avatar } from "@/components/ui/avatar";
+import { formatEventWhen, formatRelativeID } from "@/lib/format";
+import type { EventRsvpWithProfile, EventWithHost } from "@/types";
+
+type Tab = "tentang" | "detail" | "host" | "hadir";
+
+const TAB_LABELS: Record<Tab, string> = {
+  tentang: "Tentang",
+  detail: "Detail",
+  host: "Host",
+  hadir: "Hadir",
+};
+
+interface Props {
+  event: EventWithHost;
+  rsvps: EventRsvpWithProfile[];
+  isHost: boolean;
+}
+
+export function EventDetailTabs({ event, rsvps, isHost }: Props) {
+  const [activeTab, setActiveTab] = useState<Tab>("tentang");
+  const hostName = event.host.full_name ?? event.host.username ?? "host";
+  const hostHref = event.host.username ? `/profile/${event.host.username}` : "#";
+  const when = formatEventWhen(event.starts_at, event.ends_at, event.timezone);
+
+  const goingCount = rsvps.filter((r) => r.status === "going").length;
+  const maybeCount = rsvps.filter((r) => r.status === "maybe").length;
+
+  const tabs: Tab[] = [
+    "tentang",
+    "detail",
+    "host",
+    ...(rsvps.length > 0 ? (["hadir"] as Tab[]) : []),
+  ];
+
+  return (
+    <>
+      {/* ═══════════════ MOBILE ═══════════════ */}
+      <div className="md:hidden">
+        <div role="tablist" className="flex border-b border-hairline mb-5 overflow-x-auto">
+          {tabs.map((t) => (
+            <button
+              key={t}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === t}
+              onClick={() => setActiveTab(t)}
+              className={
+                "px-4 py-2.5 text-body-sm font-semibold transition-colors border-b-2 -mb-px shrink-0 " +
+                (activeTab === t
+                  ? "border-ink text-ink"
+                  : "border-transparent text-muted hover:text-ink-soft")
+              }
+            >
+              {TAB_LABELS[t]}
+              {t === "hadir" && goingCount > 0 && (
+                <span className="ml-1 text-caption text-muted">({goingCount})</span>
+              )}
+            </button>
+          ))}
+        </div>
+
+        <div className="min-h-[140px]">
+          {activeTab === "tentang" && <TentangContent event={event} isHost={isHost} />}
+          {activeTab === "detail" && <DetailContent event={event} when={when} />}
+          {activeTab === "host" && <HostContent hostHref={hostHref} hostName={hostName} event={event} />}
+          {activeTab === "hadir" && (
+            <HadirContent rsvps={rsvps} goingCount={goingCount} maybeCount={maybeCount} />
+          )}
+        </div>
+      </div>
+
+      {/* ═══════════════ DESKTOP ═══════════════ */}
+      <div className="hidden md:flex flex-col gap-6">
+        <section className="p-6 rounded-card-lg border border-hairline bg-paper shadow-card">
+          <p className="text-caption text-muted uppercase tracking-wide font-semibold mb-3">
+            Tentang event ini
+          </p>
+          <TentangContent event={event} isHost={isHost} />
+        </section>
+
+        <section className="p-6 rounded-card-lg border border-hairline bg-paper shadow-card">
+          <p className="text-caption text-muted uppercase tracking-wide font-semibold mb-3">
+            Detail
+          </p>
+          <DetailContent event={event} when={when} />
+        </section>
+
+        <Link
+          href={hostHref}
+          className="flex items-center gap-3 p-4 rounded-card border border-hairline bg-paper hover:bg-cream transition-colors"
+        >
+          <Avatar src={event.host.photo_url} name={event.host.full_name} size={48} />
+          <div className="min-w-0 flex-1">
+            <p className="text-body font-semibold text-ink truncate">{hostName}</p>
+            <p className="text-caption text-muted truncate">
+              {event.host.city ?? "Semarang"} · posted {formatRelativeID(event.created_at)}
+            </p>
+          </div>
+          <span className="text-caption text-muted shrink-0">→</span>
+        </Link>
+
+        {rsvps.length > 0 && (
+          <section className="p-5 rounded-card-lg border border-hairline bg-paper shadow-card">
+            <p className="text-caption text-muted uppercase tracking-wide font-semibold mb-3">
+              {goingCount} hadir{maybeCount > 0 ? ` · ${maybeCount} mungkin` : ""}
+            </p>
+            <HadirContent rsvps={rsvps} goingCount={goingCount} maybeCount={maybeCount} />
+          </section>
+        )}
+      </div>
+    </>
+  );
+}
+
+function TentangContent({ event, isHost }: { event: EventWithHost; isHost: boolean }) {
+  return (
+    <div>
+      {event.description ? (
+        <p className="text-body text-ink leading-relaxed whitespace-pre-wrap">{event.description}</p>
+      ) : (
+        <p className="text-body text-ink-soft leading-relaxed">
+          Belum ada deskripsi.{" "}
+          {isHost ? (
+            <Link
+              href={`/event/${event.id}/edit`}
+              className="text-ink font-semibold underline underline-offset-4 decoration-hairline-strong hover:decoration-ink"
+            >
+              Tambahin →
+            </Link>
+          ) : (
+            "Tanya langsung ke host."
+          )}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function DetailContent({ event, when }: { event: EventWithHost; when: string }) {
+  return (
+    <dl className="grid grid-cols-1 gap-y-4">
+      <DetailRow label="Kapan" value={when} />
+      {event.is_online ? (
+        <DetailRow label="Format" value="Online" />
+      ) : (
+        event.location_text && <DetailRow label="Lokasi" value={event.location_text} />
+      )}
+      {event.location_url && (
+        <div>
+          <dt className="text-caption text-muted uppercase tracking-wide font-semibold">
+            {event.is_online ? "Link meeting" : "Maps"}
+          </dt>
+          <dd className="mt-0.5">
+            <a
+              href={event.location_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-body text-ink underline underline-offset-4 hover:text-ink-soft break-all"
+            >
+              {event.location_url}
+            </a>
+          </dd>
+        </div>
+      )}
+      {event.capacity && (
+        <DetailRow label="Kapasitas" value={`${event.rsvp_count} / ${event.capacity}`} />
+      )}
+      {event.community && (
+        <DetailRow label="Komunitas" value={event.community.name} />
+      )}
+    </dl>
+  );
+}
+
+function HostContent({
+  hostHref,
+  hostName,
+  event,
+}: {
+  hostHref: string;
+  hostName: string;
+  event: EventWithHost;
+}) {
+  return (
+    <Link href={hostHref} className="flex items-center gap-3">
+      <Avatar src={event.host.photo_url} name={event.host.full_name} size={48} />
+      <div className="min-w-0 flex-1">
+        <p className="text-body font-semibold text-ink truncate">{hostName}</p>
+        <p className="text-caption text-muted truncate">
+          {event.host.city ?? "Semarang"}
+        </p>
+      </div>
+      <span className="text-caption text-muted shrink-0">→</span>
+    </Link>
+  );
+}
+
+function HadirContent({
+  rsvps,
+  goingCount,
+  maybeCount,
+}: {
+  rsvps: EventRsvpWithProfile[];
+  goingCount: number;
+  maybeCount: number;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      {goingCount > 0 && (
+        <div>
+          <p className="text-caption text-muted uppercase tracking-wide font-semibold mb-2">
+            Hadir ({goingCount})
+          </p>
+          <ul className="flex flex-col gap-2">
+            {rsvps
+              .filter((r) => r.status === "going")
+              .map((r) => (
+                <RsvpRow key={r.profile_id} rsvp={r} />
+              ))}
+          </ul>
+        </div>
+      )}
+      {maybeCount > 0 && (
+        <div>
+          <p className="text-caption text-muted uppercase tracking-wide font-semibold mb-2">
+            Mungkin ({maybeCount})
+          </p>
+          <ul className="flex flex-col gap-2">
+            {rsvps
+              .filter((r) => r.status === "maybe")
+              .map((r) => (
+                <RsvpRow key={r.profile_id} rsvp={r} />
+              ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RsvpRow({ rsvp }: { rsvp: EventRsvpWithProfile }) {
+  const profileHref = rsvp.profile.username ? `/profile/${rsvp.profile.username}` : "#";
+  return (
+    <li>
+      <Link href={profileHref} className="flex items-center gap-2.5 hover:opacity-80">
+        <Avatar src={rsvp.profile.photo_url} name={rsvp.profile.full_name} size={32} />
+        <p className="text-body-sm text-ink truncate">
+          {rsvp.profile.full_name ?? rsvp.profile.username ?? "Anggota"}
+        </p>
+      </Link>
+    </li>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-caption text-muted uppercase tracking-wide font-semibold">{label}</dt>
+      <dd className="mt-0.5 text-body text-ink">{value}</dd>
+    </div>
+  );
+}

--- a/components/events/event-form.tsx
+++ b/components/events/event-form.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { createClient } from "@/lib/supabase/client";
+import { Input, Textarea, Select } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import type { ContactMethod, Event, EventFormValues, EventVisibility } from "@/types";
+
+type Step = 1 | 2;
+type Mode = "create" | "edit";
+
+interface Props {
+  userId: string;
+  mode: Mode;
+  initial?: Event;
+}
+
+const CONTACT_OPTIONS: { value: ContactMethod; label: string }[] = [
+  { value: "whatsapp", label: "WhatsApp" },
+  { value: "instagram", label: "Instagram" },
+  { value: "discord", label: "Discord" },
+];
+
+const VISIBILITY_OPTIONS: { value: EventVisibility; label: string }[] = [
+  { value: "public", label: "Publik — semua bisa lihat" },
+  { value: "community", label: "Komunitas — anggota Journey Perintis" },
+];
+
+export function EventForm({ userId, mode, initial }: Props) {
+  const router = useRouter();
+  const [step, setStep] = useState<Step>(1);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [title, setTitle] = useState(initial?.title ?? "");
+  const [startsAt, setStartsAt] = useState(
+    initial?.starts_at ? initial.starts_at.slice(0, 16) : "",
+  );
+  const [endsAt, setEndsAt] = useState(
+    initial?.ends_at ? initial.ends_at.slice(0, 16) : "",
+  );
+  const [locationText, setLocationText] = useState(initial?.location_text ?? "");
+  const [locationUrl, setLocationUrl] = useState(initial?.location_url ?? "");
+  const [isOnline, setIsOnline] = useState(initial?.is_online ?? false);
+
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [capacity, setCapacity] = useState(initial?.capacity?.toString() ?? "");
+  const [coverUrl, setCoverUrl] = useState(initial?.cover_url ?? "");
+  const [contactMethod, setContactMethod] = useState<ContactMethod>(
+    initial?.contact_method ?? "whatsapp",
+  );
+  const [visibility, setVisibility] = useState<EventVisibility>(
+    initial?.visibility ?? "public",
+  );
+
+  function validateStep1(): string | null {
+    if (title.trim().length < 3) return "Judul event minimal 3 karakter.";
+    if (!startsAt) return "Tanggal mulai harus diisi.";
+    if (endsAt && endsAt <= startsAt) return "Waktu selesai harus setelah waktu mulai.";
+    if (!isOnline && !locationText.trim()) return "Lokasi event harus diisi (atau centang Online).";
+    return null;
+  }
+
+  async function handleSubmit() {
+    setError(null);
+    setSaving(true);
+
+    const supabase = createClient();
+    const values: EventFormValues = {
+      title: title.trim(),
+      description: description.trim() || undefined,
+      starts_at: new Date(startsAt).toISOString(),
+      ends_at: endsAt ? new Date(endsAt).toISOString() : undefined,
+      location_text: locationText.trim() || undefined,
+      location_url: locationUrl.trim() || undefined,
+      is_online: isOnline,
+      capacity: capacity ? parseInt(capacity, 10) : undefined,
+      cover_url: coverUrl.trim() || undefined,
+      contact_method: contactMethod,
+      visibility,
+    };
+
+    try {
+      if (mode === "create") {
+        const { data, error: insertErr } = await supabase
+          .from("events")
+          .insert({ ...values, host_id: userId })
+          .select("id")
+          .single();
+
+        if (insertErr || !data) {
+          setError(insertErr?.message ?? "Gagal bikin event.");
+          return;
+        }
+        toast.success("Event berhasil dibuat!");
+        router.replace(`/event/${data.id as string}`);
+      } else {
+        const { error: updateErr } = await supabase
+          .from("events")
+          .update(values)
+          .eq("id", initial!.id);
+
+        if (updateErr) {
+          setError(updateErr.message);
+          return;
+        }
+        toast.success("Event diupdate.");
+        router.replace(`/event/${initial!.id}`);
+        router.refresh();
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="max-w-xl mx-auto flex flex-col gap-6">
+      {/* Step indicator */}
+      <div className="flex items-center gap-2">
+        {([1, 2] as Step[]).map((s) => (
+          <div
+            key={s}
+            className={
+              "h-1.5 flex-1 rounded-full transition-colors " +
+              (step >= s ? "bg-ink" : "bg-cream border border-hairline")
+            }
+          />
+        ))}
+      </div>
+
+      {error && (
+        <p className="text-body-sm text-red-700 bg-red-50 border border-red-200 rounded-card px-4 py-3">
+          {error}
+        </p>
+      )}
+
+      {/* ── Step 1: When & Where ── */}
+      {step === 1 && (
+        <div className="flex flex-col gap-5">
+          <div>
+            <label className="block text-body-sm font-semibold text-ink mb-1.5">
+              Judul event <span className="text-red-500">*</span>
+            </label>
+            <Input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Contoh: Diskusi Buku Bulan Mei"
+              maxLength={140}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-body-sm font-semibold text-ink mb-1.5">
+                Mulai <span className="text-red-500">*</span>
+              </label>
+              <Input
+                type="datetime-local"
+                value={startsAt}
+                onChange={(e) => setStartsAt(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="block text-body-sm font-semibold text-ink mb-1.5">
+                Selesai
+              </label>
+              <Input
+                type="datetime-local"
+                value={endsAt}
+                onChange={(e) => setEndsAt(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="is_online"
+              checked={isOnline}
+              onChange={(e) => setIsOnline(e.target.checked)}
+              className="w-4 h-4 accent-ink"
+            />
+            <label htmlFor="is_online" className="text-body-sm text-ink">
+              Event online
+            </label>
+          </div>
+
+          {!isOnline && (
+            <div>
+              <label className="block text-body-sm font-semibold text-ink mb-1.5">
+                Lokasi <span className="text-red-500">*</span>
+              </label>
+              <Input
+                value={locationText}
+                onChange={(e) => setLocationText(e.target.value)}
+                placeholder="Contoh: Treetales Coffee, Semarang"
+              />
+            </div>
+          )}
+
+          {(isOnline || locationText) && (
+            <div>
+              <label className="block text-body-sm font-semibold text-ink mb-1.5">
+                Link {isOnline ? "meeting" : "Google Maps"} (opsional)
+              </label>
+              <Input
+                type="url"
+                value={locationUrl}
+                onChange={(e) => setLocationUrl(e.target.value)}
+                placeholder="https://..."
+              />
+            </div>
+          )}
+
+          <Button
+            onClick={() => {
+              const err = validateStep1();
+              if (err) { setError(err); return; }
+              setError(null);
+              setStep(2);
+            }}
+            className="w-full"
+          >
+            Lanjut →
+          </Button>
+        </div>
+      )}
+
+      {/* ── Step 2: Details ── */}
+      {step === 2 && (
+        <div className="flex flex-col gap-5">
+          <div>
+            <label className="block text-body-sm font-semibold text-ink mb-1.5">
+              Deskripsi (opsional)
+            </label>
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Ceritain event ini buat yang belum tau..."
+              rows={4}
+              maxLength={4000}
+            />
+          </div>
+
+          <div>
+            <label className="block text-body-sm font-semibold text-ink mb-1.5">
+              Kapasitas (opsional)
+            </label>
+            <Input
+              type="number"
+              value={capacity}
+              onChange={(e) => setCapacity(e.target.value)}
+              placeholder="Kosongi kalau tidak terbatas"
+              min={1}
+            />
+          </div>
+
+          <div>
+            <label className="block text-body-sm font-semibold text-ink mb-1.5">
+              URL cover (opsional)
+            </label>
+            <Input
+              type="url"
+              value={coverUrl}
+              onChange={(e) => setCoverUrl(e.target.value)}
+              placeholder="https://... (link gambar)"
+            />
+          </div>
+
+          <div>
+            <label className="block text-body-sm font-semibold text-ink mb-1.5">
+              Kontak host
+            </label>
+            <Select
+              value={contactMethod}
+              onChange={(e) => setContactMethod(e.target.value as ContactMethod)}
+            >
+              {CONTACT_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </Select>
+          </div>
+
+          <div>
+            <label className="block text-body-sm font-semibold text-ink mb-1.5">
+              Siapa yang bisa lihat
+            </label>
+            <Select
+              value={visibility}
+              onChange={(e) => setVisibility(e.target.value as EventVisibility)}
+            >
+              {VISIBILITY_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </Select>
+          </div>
+
+          <div className="flex gap-3">
+            <Button
+              variant="secondary"
+              onClick={() => { setError(null); setStep(1); }}
+              className="flex-1"
+              disabled={saving}
+            >
+              ← Balik
+            </Button>
+            <Button onClick={handleSubmit} className="flex-1" disabled={saving}>
+              {saving ? "Menyimpan..." : mode === "create" ? "Buat Event" : "Simpan Perubahan"}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/events/rsvp-button.tsx
+++ b/components/events/rsvp-button.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useOptimistic, useTransition, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import type { EventRsvpStatus } from "@/types";
+
+interface Props {
+  eventId: string;
+  initialStatus: EventRsvpStatus | null;
+  isAuthed: boolean;
+}
+
+const NEXT_STATUS: Record<EventRsvpStatus, EventRsvpStatus | null> = {
+  going: "maybe",
+  maybe: null,
+  declined: "going",
+};
+
+export function RsvpButton({ eventId, initialStatus, isAuthed }: Props) {
+  const [, startTransition] = useTransition();
+  const [optimisticStatus, setOptimisticStatus] = useOptimistic(initialStatus);
+  const [busy, setBusy] = useState(false);
+
+  if (!isAuthed) {
+    return (
+      <a
+        href={`/auth/login?next=/event/${eventId}`}
+        className="inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-card bg-ink text-paper text-body-sm font-semibold hover:bg-ink/90 transition-colors w-full"
+      >
+        Hadir di event ini →
+      </a>
+    );
+  }
+
+  async function toggle() {
+    if (busy) return;
+    setBusy(true);
+
+    const currentStatus = optimisticStatus;
+    const next = currentStatus === null ? "going" : NEXT_STATUS[currentStatus];
+
+    startTransition(() => {
+      setOptimisticStatus(next);
+    });
+
+    try {
+      if (next === null) {
+        const res = await fetch(`/api/events/${eventId}/rsvp`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: null }),
+        });
+        if (!res.ok) throw new Error("Gagal cancel RSVP.");
+        toast.success("RSVP dibatalkan.");
+      } else {
+        const res = await fetch(`/api/events/${eventId}/rsvp`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: next }),
+        });
+        if (!res.ok) throw new Error("Gagal update RSVP.");
+        const label = next === "going" ? "Oke, lo bakal hadir! 🎉" : "Tercatat sebagai 'mungkin hadir'.";
+        toast.success(label);
+      }
+    } catch (err) {
+      startTransition(() => {
+        setOptimisticStatus(currentStatus);
+      });
+      toast.error(err instanceof Error ? err.message : "Gagal update RSVP.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const label =
+    optimisticStatus === null
+      ? "Hadir di event ini"
+      : optimisticStatus === "going"
+      ? "✓ Bakal hadir — klik untuk ganti ke Mungkin"
+      : optimisticStatus === "maybe"
+      ? "~ Mungkin hadir — klik untuk batal"
+      : "Hadir di event ini";
+
+  const variant = optimisticStatus === "going" ? "secondary" : optimisticStatus === "maybe" ? "secondary" : "default";
+
+  return (
+    <Button
+      variant={variant}
+      onClick={toggle}
+      disabled={busy}
+      className="w-full"
+    >
+      {busy ? "Menyimpan..." : label}
+    </Button>
+  );
+}

--- a/components/events/rsvp-button.tsx
+++ b/components/events/rsvp-button.tsx
@@ -82,7 +82,8 @@ export function RsvpButton({ eventId, initialStatus, isAuthed }: Props) {
       ? "~ Mungkin hadir — klik untuk batal"
       : "Hadir di event ini";
 
-  const variant = optimisticStatus === "going" ? "secondary" : optimisticStatus === "maybe" ? "secondary" : "default";
+  const variant: "primary" | "secondary" =
+    optimisticStatus === null ? "primary" : "secondary";
 
   return (
     <Button

--- a/components/landing/upcoming-events-strip.tsx
+++ b/components/landing/upcoming-events-strip.tsx
@@ -1,0 +1,93 @@
+import Image from "next/image";
+import { getUpcomingEvents } from "@/lib/events";
+import { formatEventWhen } from "@/lib/format";
+import { GatedLink } from "./gated-link";
+
+/**
+ * Horizontal-scroll strip of upcoming community events — landing social proof.
+ * Pulls up to 8 upcoming scheduled events ordered by starts_at asc.
+ * Returns null when no upcoming events so the landing page stays clean on a fresh deploy.
+ */
+export async function UpcomingEventsStrip() {
+  const events = await getUpcomingEvents(8);
+  if (events.length === 0) return null;
+
+  return (
+    <section
+      className="px-6 md:px-10 py-12"
+      aria-label="Event komunitas yang akan datang"
+    >
+      <div className="max-w-5xl mx-auto">
+        <div className="flex items-end justify-between gap-3 mb-5">
+          <div>
+            <p className="text-caption text-muted uppercase tracking-wide font-semibold">
+              Events
+            </p>
+            <h2 className="mt-1 font-display text-display-md md:text-display-lg text-ink leading-tight">
+              Yang akan datang
+            </h2>
+          </div>
+          <GatedLink
+            href="/event"
+            className="shrink-0 text-body-sm font-medium text-ink hover:underline underline-offset-4"
+          >
+            Lihat semua →
+          </GatedLink>
+        </div>
+
+        <div
+          className="flex gap-3 overflow-x-auto scrollbar-none snap-x snap-mandatory -mx-6 px-6 md:-mx-10 md:px-10 pb-2"
+          aria-label="Daftar event — geser ke samping"
+        >
+          {events.map((ev) => {
+            const when = formatEventWhen(ev.starts_at, ev.ends_at, ev.timezone);
+            return (
+              <GatedLink
+                key={ev.id}
+                href={`/event/${ev.id}`}
+                className="group shrink-0 snap-start w-[220px] flex flex-col gap-2"
+              >
+                <div className="relative w-[220px] aspect-video rounded-card overflow-hidden bg-cream border border-hairline shadow-card group-hover:shadow-card-hover transition-shadow">
+                  {ev.cover_url ? (
+                    <Image
+                      src={ev.cover_url}
+                      alt=""
+                      fill
+                      sizes="220px"
+                      className="object-cover"
+                    />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center p-4 bg-gradient-to-br from-cream to-parchment">
+                      <p className="font-display text-title-sm text-ink line-clamp-2 text-center">
+                        {ev.title}
+                      </p>
+                    </div>
+                  )}
+                  {ev.is_online && (
+                    <span className="absolute top-2 left-2 px-2 py-0.5 rounded-full bg-ink/70 text-paper text-caption font-semibold">
+                      Online
+                    </span>
+                  )}
+                </div>
+                <div className="min-w-0">
+                  <p className="text-caption text-muted font-medium leading-tight truncate">
+                    {when}
+                  </p>
+                  <p className="text-body-sm font-semibold text-ink line-clamp-2 leading-snug mt-0.5">
+                    {ev.title}
+                  </p>
+                  {ev.location_text && !ev.is_online && (
+                    <p className="text-caption text-muted truncate">{ev.location_text}</p>
+                  )}
+                  {ev.rsvp_count > 0 && (
+                    <p className="text-caption text-muted mt-0.5">{ev.rsvp_count} hadir</p>
+                  )}
+                </div>
+              </GatedLink>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -111,6 +111,7 @@ Migrations applied (0001-0004) and pending (0005-0007):
 | 0015 | mastermind_okrs | ⏳ pending | `okr_objectives` + `okr_key_results` tables, admin-only RLS, seeded Q2 2026 (5 Objectives + 25+ KRs verbatim from masterprompt). KRs with `auto_compute_key` resolved live via `lib/mastermind/kr-compute.ts`. Powers `/mastermind/okrs`. |
 | 0016 | mastermind_tasks | ⏳ pending | `team_tasks` table, admin-only RLS, FK link to `okr_objectives` + `okr_key_results`. Seeded with 14 ownership tasks from masterprompt. Powers `/mastermind/team`. |
 | 0017 | mastermind_admin_notes | ⏳ pending | `admin_notes` polymorphic table (entity_type/id) for inline founder annotations across users/books/wanted/feedback/okr/task. Adds `audit_log` admin SELECT policy (was service-role only). |
+| 0020 | events | ⏳ pending | `events` + `event_rsvps` tables, RLS (events mirror books, rsvps mirror saved_books). Extends `activity_log` with `EVENT_CREATED` + `EVENT_RSVPED` types and `event_id` FK column. RSVPed trigger only fires on INSERT with `status='going'` so toggling maybe→going→maybe doesn't spam the feed. |
 
 SQL for 0005-0007 is in `docs/PRE-DEPLOY-CHECKLIST.md` (deprecated; use the migration files in `supabase/migrations/`).
 
@@ -122,6 +123,7 @@ SQL for 0005-0007 is in `docs/PRE-DEPLOY-CHECKLIST.md` (deprecated; use the migr
 | 2   | Custom domain SMTP (Path B)                                                 | Resend domain verify + Supabase SMTP            | Yes for inviting JP — currently only journey.perintis@gmail.com receives |
 | 3   | Optional: Vercel `NEXT_PUBLIC_APP_URL=https://collectivelibrary.vercel.app` | Vercel env vars                                 | Soft-blocking — falls back to VERCEL_URL otherwise                       |
 | 4   | Rotate API keys/secrets shared during chat                                  | Resend, hCaptcha, Sentry, Discord, Supabase     | Recommended pre-launch                                                   |
+| 5   | Optional: `DISCORD_EVENTS_WEBHOOK_URL` for event announcements              | Vercel env vars                                 | No — falls back to `DISCORD_FEEDBACK_WEBHOOK_URL` if unset               |
 
 ## Strategic guardrails (from product philosophy doc)
 
@@ -140,6 +142,7 @@ If all four are no, we don't build it.
 
 ---
 
+- **~~Event Management MVP~~** ✅ shipped — Phase 1 "activation spine" from the Business Model Canvas. `/event`, `/event/new`, `/event/[id]`, `/event/[id]/edit` routes (all auth-gated like `/book/[id]`). 2-step create form (when+where / details), 3-state RSVP toggle (going/maybe/cancel) with `useOptimistic` + `useTransition`, host-only Discord announce button (idempotent via `discord_announced_at`, reuses `DISCORD_FEEDBACK_WEBHOOK_URL` if `DISCORD_EVENTS_WEBHOOK_URL` unset). Activity feed integration: `EVENT_CREATED` + `EVENT_RSVPED` types in `activity_log` (trigger fires on INSERT only with `status='going'` so RSVP toggles don't spam). Landing strip `<UpcomingEventsStrip />` between RecentBooks and ActivityFeed on `/`, additional `EventCard` grid above ActivityFeed on `/shelf` (only on unfiltered page 1). RSS + JSON Feed both updated to emit `/event/[id]` permalinks with cover thumbnails. Migration `0020_events.sql` re-runnable. Deferred (next slices): cover-image upload, recurring events, ticketing, comments, check-in, place picker, capacity hard-enforcement, calendar export, co-hosts.
 - **~~Map view~~** ✅ shipped — `/peta` with Leaflet + Carto Positron tiles. Snapchat-style avatar markers (photo bubble + book-count badge), deterministic jitter so same-kecamatan members don't perfectly overlap. Opt-in via `show_on_map` toggle on profile edit. Coords stored at kecamatan-level only via Nominatim save-time geocoding (`/api/geocode`, auth-gated, 30-day CDN cache). Works for any Indonesian kecamatan (not Semarang-only).
 - **Per-user Discord DM** — needs proper Discord bot infra. Current channel webhook is community-level only.
 - **~~3-layer interest~~** ✅ shipped — Layer 1 (broad), Layer 2 (sub-interest, gated by L1), Layer 3 (intent — what they want to DO). Stored as 3 separate `text[]` columns. /anggota gets a new "Available untuk" filter row driven by intent. Profile page displays all 3 layers with distinct visual weights (dark / light / accent-green).

--- a/lib/activity.ts
+++ b/lib/activity.ts
@@ -5,7 +5,9 @@ export type ActivityType =
   | "USER_JOINED"
   | "BOOK_ADDED"
   | "BOOK_STATUS_CHANGED"
-  | "WTB_POSTED";
+  | "WTB_POSTED"
+  | "EVENT_CREATED"
+  | "EVENT_RSVPED";
 
 export interface ActivityActor {
   id: string;
@@ -28,21 +30,30 @@ export interface ActivityWanted {
   author: string | null;
 }
 
+export interface ActivityEvent {
+  id: string;
+  title: string;
+  starts_at: string;
+  cover_url: string | null;
+}
+
 export interface ActivityItem {
   id: string;
   type: ActivityType;
   created_at: string;
-  metadata: { old_status?: BookStatus; new_status?: BookStatus } | null;
+  metadata: { old_status?: BookStatus; new_status?: BookStatus; rsvp_status?: string } | null;
   actor: ActivityActor | null;
   book: ActivityBook | null;
   wanted: ActivityWanted | null;
+  event: ActivityEvent | null;
 }
 
 const SELECT = `
   id, type, created_at, metadata,
   actor:profiles_public!actor_user_id(id, full_name, username, photo_url),
   book:books(id, title, author, cover_url, status),
-  wanted:wanted_requests(id, title, author)
+  wanted:wanted_requests(id, title, author),
+  event:events(id, title, starts_at, cover_url)
 `;
 
 /**
@@ -91,6 +102,7 @@ export async function listActivity(
     actor: ActivityActor | ActivityActor[] | null;
     book: ActivityBook | ActivityBook[] | null;
     wanted: ActivityWanted | ActivityWanted[] | null;
+    event: ActivityEvent | ActivityEvent[] | null;
   };
 
   // Supabase types embedded relations as arrays; flatten to single object.
@@ -105,5 +117,6 @@ export async function listActivity(
     actor: flatten(r.actor),
     book: flatten(r.book),
     wanted: flatten(r.wanted),
+    event: flatten(r.event),
   }));
 }

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -79,9 +79,9 @@ export async function listEvents(opts?: {
     ...r,
     host: flatten(r.host as never),
     community: flatten(r.community as never),
-    rsvp_count: (r.rsvps?.[0] as { count: number } | undefined)?.count ?? 0,
+    rsvp_count: r.rsvps?.[0]?.count ?? 0,
     viewer_rsvp: null,
-  })) as EventWithHost[];
+  })) as unknown as EventWithHost[];
 
   return { events, total: count ?? 0 };
 }
@@ -123,9 +123,9 @@ export async function getUpcomingEvents(limit = 8): Promise<EventWithHost[]> {
     ...r,
     host: flatten(r.host as never),
     community: flatten(r.community as never),
-    rsvp_count: (r.rsvps?.[0] as { count: number } | undefined)?.count ?? 0,
+    rsvp_count: r.rsvps?.[0]?.count ?? 0,
     viewer_rsvp: null,
-  })) as EventWithHost[];
+  })) as unknown as EventWithHost[];
 }
 
 /**
@@ -180,9 +180,9 @@ export async function getEvent(
     ...row,
     host: flatten(row.host as never),
     community: flatten(row.community as never),
-    rsvp_count: (row.rsvps?.[0] as { count: number } | undefined)?.count ?? 0,
+    rsvp_count: row.rsvps?.[0]?.count ?? 0,
     viewer_rsvp: viewerRsvp,
-  } as EventWithHost;
+  } as unknown as EventWithHost;
 }
 
 /** Create a new event. Returns the new row id on success or an error string. */
@@ -342,7 +342,7 @@ export async function listEventRsvps(eventId: string): Promise<EventRsvpWithProf
   return ((data ?? []) as unknown as Row[]).map((r) => ({
     ...r,
     profile: flatten(r.profile as never),
-  })) as EventRsvpWithProfile[];
+  })) as unknown as EventRsvpWithProfile[];
 }
 
 /** Fetch a raw Event row (no joins). Used by API routes that just need ownership check. */

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,0 +1,363 @@
+import { createClient } from "@/lib/supabase/server";
+import type {
+  Event,
+  EventFormValues,
+  EventRsvpStatus,
+  EventRsvpWithProfile,
+  EventStatus,
+  EventWithHost,
+} from "@/types";
+
+const HOST_SELECT = `id, full_name, username, photo_url, city, whatsapp, whatsapp_public, instagram, discord`;
+
+const EVENT_LIST_COLUMNS = `id, host_id, community_id, title, starts_at, ends_at, timezone, location_text, location_url, is_online, capacity, cover_url, visibility, status, is_hidden, discord_announced_at, created_at, updated_at`;
+
+// Supabase returns embedded relations as arrays; flatten to single object.
+const flatten = <T,>(v: T | T[] | null): T | null =>
+  Array.isArray(v) ? (v[0] ?? null) : v;
+
+/**
+ * List events with optional filter, pagination, and host scoping.
+ * Default: upcoming events ordered by starts_at ascending.
+ */
+export async function listEvents(opts?: {
+  filter?: "upcoming" | "past" | "all";
+  hostId?: string;
+  page?: number;
+  pageSize?: number;
+}): Promise<{ events: EventWithHost[]; total: number }> {
+  const supabase = await createClient();
+  const pageSize = Math.max(1, Math.min(opts?.pageSize ?? 20, 60));
+  const page = Math.max(1, opts?.page ?? 1);
+  const from = (page - 1) * pageSize;
+  const to = from + pageSize - 1;
+  const now = new Date().toISOString();
+  const filter = opts?.filter ?? "upcoming";
+
+  let query = supabase
+    .from("events")
+    .select(
+      `${EVENT_LIST_COLUMNS},
+       host:profiles_public!events_host_id_fkey(${HOST_SELECT}),
+       community:communities(id, name, slug),
+       rsvps:event_rsvps(count)`,
+      { count: "exact" },
+    )
+    .eq("is_hidden", false)
+    .range(from, to);
+
+  if (filter === "upcoming") {
+    query = query
+      .gte("starts_at", now)
+      .in("status", ["scheduled"])
+      .order("starts_at", { ascending: true });
+  } else if (filter === "past") {
+    query = query
+      .lt("starts_at", now)
+      .order("starts_at", { ascending: false });
+  } else {
+    query = query.order("starts_at", { ascending: false });
+  }
+
+  if (opts?.hostId) {
+    query = query.eq("host_id", opts.hostId);
+  }
+
+  const { data, error, count } = await query;
+  if (error) {
+    console.error("listEvents", error);
+    return { events: [], total: 0 };
+  }
+
+  type Row = {
+    host: unknown;
+    community: unknown;
+    rsvps: Array<{ count: number }> | null;
+  } & Record<string, unknown>;
+
+  const events = ((data ?? []) as unknown as Row[]).map((r) => ({
+    ...r,
+    host: flatten(r.host as never),
+    community: flatten(r.community as never),
+    rsvp_count: (r.rsvps?.[0] as { count: number } | undefined)?.count ?? 0,
+    viewer_rsvp: null,
+  })) as EventWithHost[];
+
+  return { events, total: count ?? 0 };
+}
+
+/**
+ * Upcoming events for the landing strip and shelf widget.
+ * Skips pagination — returns just the first N events.
+ */
+export async function getUpcomingEvents(limit = 8): Promise<EventWithHost[]> {
+  const supabase = await createClient();
+  const now = new Date().toISOString();
+
+  const { data, error } = await supabase
+    .from("events")
+    .select(
+      `${EVENT_LIST_COLUMNS},
+       host:profiles_public!events_host_id_fkey(${HOST_SELECT}),
+       community:communities(id, name, slug),
+       rsvps:event_rsvps(count)`,
+    )
+    .eq("is_hidden", false)
+    .eq("status", "scheduled")
+    .gte("starts_at", now)
+    .order("starts_at", { ascending: true })
+    .limit(limit);
+
+  if (error) {
+    console.error("getUpcomingEvents", error);
+    return [];
+  }
+
+  type Row = {
+    host: unknown;
+    community: unknown;
+    rsvps: Array<{ count: number }> | null;
+  } & Record<string, unknown>;
+
+  return ((data ?? []) as unknown as Row[]).map((r) => ({
+    ...r,
+    host: flatten(r.host as never),
+    community: flatten(r.community as never),
+    rsvp_count: (r.rsvps?.[0] as { count: number } | undefined)?.count ?? 0,
+    viewer_rsvp: null,
+  })) as EventWithHost[];
+}
+
+/**
+ * Single event detail with host profile, community, RSVP count, and the
+ * requesting viewer's own RSVP status (null when called server-side without
+ * a viewer session — callers supply viewerId explicitly).
+ */
+export async function getEvent(
+  id: string,
+  viewerId?: string,
+): Promise<EventWithHost | null> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("events")
+    .select(
+      `*,
+       host:profiles_public!events_host_id_fkey(${HOST_SELECT}),
+       community:communities(id, name, slug),
+       rsvps:event_rsvps(count)`,
+    )
+    .eq("id", id)
+    .eq("is_hidden", false)
+    .maybeSingle();
+
+  if (error) {
+    console.error("getEvent", error);
+    return null;
+  }
+  if (!data) return null;
+
+  type Row = {
+    host: unknown;
+    community: unknown;
+    rsvps: Array<{ count: number }> | null;
+  } & Record<string, unknown>;
+
+  const row = data as unknown as Row;
+  let viewerRsvp: EventRsvpStatus | null = null;
+
+  if (viewerId) {
+    const { data: rsvpRow } = await supabase
+      .from("event_rsvps")
+      .select("status")
+      .eq("event_id", id)
+      .eq("profile_id", viewerId)
+      .maybeSingle();
+    viewerRsvp = (rsvpRow?.status as EventRsvpStatus) ?? null;
+  }
+
+  return {
+    ...row,
+    host: flatten(row.host as never),
+    community: flatten(row.community as never),
+    rsvp_count: (row.rsvps?.[0] as { count: number } | undefined)?.count ?? 0,
+    viewer_rsvp: viewerRsvp,
+  } as EventWithHost;
+}
+
+/** Create a new event. Returns the new row id on success or an error string. */
+export async function createEvent(
+  hostId: string,
+  values: EventFormValues,
+): Promise<{ id: string } | { error: string }> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("events")
+    .insert({
+      host_id: hostId,
+      title: values.title,
+      description: values.description ?? null,
+      starts_at: values.starts_at,
+      ends_at: values.ends_at ?? null,
+      timezone: values.timezone ?? "Asia/Jakarta",
+      location_text: values.location_text ?? null,
+      location_url: values.location_url ?? null,
+      is_online: values.is_online ?? false,
+      capacity: values.capacity ?? null,
+      cover_url: values.cover_url ?? null,
+      contact_method: values.contact_method ?? "whatsapp",
+      visibility: values.visibility ?? "public",
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    console.error("createEvent", error);
+    return { error: error.message };
+  }
+  return { id: data.id as string };
+}
+
+/** Update an event. Host ownership is enforced by RLS. */
+export async function updateEvent(
+  id: string,
+  patch: Partial<EventFormValues> & { status?: EventStatus },
+): Promise<{ ok: true } | { error: string }> {
+  const supabase = await createClient();
+
+  const { error } = await supabase
+    .from("events")
+    .update({
+      ...(patch.title !== undefined && { title: patch.title }),
+      ...(patch.description !== undefined && { description: patch.description }),
+      ...(patch.starts_at !== undefined && { starts_at: patch.starts_at }),
+      ...(patch.ends_at !== undefined && { ends_at: patch.ends_at }),
+      ...(patch.timezone !== undefined && { timezone: patch.timezone }),
+      ...(patch.location_text !== undefined && { location_text: patch.location_text }),
+      ...(patch.location_url !== undefined && { location_url: patch.location_url }),
+      ...(patch.is_online !== undefined && { is_online: patch.is_online }),
+      ...(patch.capacity !== undefined && { capacity: patch.capacity }),
+      ...(patch.cover_url !== undefined && { cover_url: patch.cover_url }),
+      ...(patch.contact_method !== undefined && { contact_method: patch.contact_method }),
+      ...(patch.visibility !== undefined && { visibility: patch.visibility }),
+      ...(patch.status !== undefined && { status: patch.status }),
+    })
+    .eq("id", id);
+
+  if (error) {
+    console.error("updateEvent", error);
+    return { error: error.message };
+  }
+  return { ok: true };
+}
+
+/** Soft-delete: set is_hidden = true so activity_log cascade keeps history. */
+export async function deleteEvent(id: string): Promise<{ ok: true } | { error: string }> {
+  const supabase = await createClient();
+
+  const { error } = await supabase
+    .from("events")
+    .update({ is_hidden: true, status: "cancelled" })
+    .eq("id", id);
+
+  if (error) {
+    console.error("deleteEvent", error);
+    return { error: error.message };
+  }
+  return { ok: true };
+}
+
+/**
+ * Upsert an RSVP for a profile. The trigger only fires on INSERT so
+ * updating going → maybe → going doesn't create duplicate activity rows.
+ */
+export async function rsvpEvent(
+  eventId: string,
+  profileId: string,
+  status: EventRsvpStatus,
+  note?: string,
+): Promise<{ ok: true } | { error: string }> {
+  const supabase = await createClient();
+
+  const { error } = await supabase.from("event_rsvps").upsert(
+    {
+      event_id: eventId,
+      profile_id: profileId,
+      status,
+      note: note ?? null,
+    },
+    { onConflict: "event_id,profile_id" },
+  );
+
+  if (error) {
+    console.error("rsvpEvent", error);
+    return { error: error.message };
+  }
+  return { ok: true };
+}
+
+/** Remove a profile's RSVP entirely (cancel attendance). */
+export async function cancelRsvp(
+  eventId: string,
+  profileId: string,
+): Promise<{ ok: true } | { error: string }> {
+  const supabase = await createClient();
+
+  const { error } = await supabase
+    .from("event_rsvps")
+    .delete()
+    .eq("event_id", eventId)
+    .eq("profile_id", profileId);
+
+  if (error) {
+    console.error("cancelRsvp", error);
+    return { error: error.message };
+  }
+  return { ok: true };
+}
+
+/** All RSVPs for an event with attendee profile data, for the "Hadir" tab. */
+export async function listEventRsvps(eventId: string): Promise<EventRsvpWithProfile[]> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("event_rsvps")
+    .select(
+      `event_id, profile_id, status, note, created_at,
+       profile:profiles_public!event_rsvps_profile_id_fkey(id, full_name, username, photo_url)`,
+    )
+    .eq("event_id", eventId)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    console.error("listEventRsvps", error);
+    return [];
+  }
+
+  type Row = {
+    profile: unknown;
+  } & Record<string, unknown>;
+
+  return ((data ?? []) as unknown as Row[]).map((r) => ({
+    ...r,
+    profile: flatten(r.profile as never),
+  })) as EventRsvpWithProfile[];
+}
+
+/** Fetch a raw Event row (no joins). Used by API routes that just need ownership check. */
+export async function getRawEvent(id: string): Promise<Event | null> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("events")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    console.error("getRawEvent", error);
+    return null;
+  }
+  return data as Event | null;
+}

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -41,6 +41,40 @@ export function slugify(input: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
+/**
+ * Formats an event's start time as a readable Indonesian date-time string.
+ * e.g. "Sab, 25 Mei 2026 · 19:00 WIB"
+ */
+export function formatEventWhen(
+  startsAt: string,
+  endsAt?: string | null,
+  timezone = "Asia/Jakarta",
+): string {
+  const tzLabel: Record<string, string> = {
+    "Asia/Jakarta": "WIB",
+    "Asia/Makassar": "WITA",
+    "Asia/Jayapura": "WIT",
+  };
+  const label = tzLabel[timezone] ?? timezone;
+
+  const fmt = (iso: string, opts: Intl.DateTimeFormatOptions) =>
+    new Date(iso).toLocaleString("id-ID", { timeZone: timezone, ...opts });
+
+  const date = fmt(startsAt, {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+  const time = fmt(startsAt, { hour: "2-digit", minute: "2-digit", hour12: false });
+
+  if (endsAt) {
+    const endTime = fmt(endsAt, { hour: "2-digit", minute: "2-digit", hour12: false });
+    return `${date} · ${time}–${endTime} ${label}`;
+  }
+  return `${date} · ${time} ${label}`;
+}
+
 /** Normalizes a phone number for DB storage (remove non-digits, 0 -> 62). */
 export function normalizePhone(input: string | null | undefined): string | null {
   if (!input) return null;

--- a/proxy.ts
+++ b/proxy.ts
@@ -44,6 +44,7 @@ export async function proxy(request: NextRequest) {
     pathname.startsWith("/shelf") ||
     pathname.startsWith("/book") ||
     pathname.startsWith("/wanted") ||
+    pathname.startsWith("/event") ||
     pathname.startsWith("/profile/edit") ||
     pathname.startsWith("/onboarding") ||
     pathname.startsWith("/mastermind") ||

--- a/supabase/migrations/0020_events.sql
+++ b/supabase/migrations/0020_events.sql
@@ -1,0 +1,184 @@
+-- =============================================================================
+-- Migration 0020 — Events + RSVPs (Phase 1 "activation spine")
+--
+-- Adds two tables (events, event_rsvps) and extends activity_log so event
+-- creation + RSVPs surface in the unified feed, RSS, and JSON Feed. Mirrors:
+--   - books RLS pattern (0001_init.sql) for events
+--   - saved_books / community_members composite-PK pattern for event_rsvps
+--   - activity_log trigger philosophy from 0004 + 0018 (INSERT-only, no spam)
+--
+-- Manual Discord announce uses events.discord_announced_at as idempotency
+-- timestamp (UI shows "Diumumkan X menit lalu — umumkan lagi?").
+-- =============================================================================
+
+-- =============================================================================
+-- 1. events table
+-- =============================================================================
+create table if not exists public.events (
+  id uuid primary key default gen_random_uuid(),
+  host_id uuid not null references public.profiles(id) on delete cascade,
+  community_id uuid references public.communities(id) on delete set null,
+  title text not null check (length(title) between 3 and 140),
+  description text check (length(description) <= 4000),
+  starts_at timestamptz not null,
+  ends_at timestamptz check (ends_at is null or ends_at > starts_at),
+  timezone text not null default 'Asia/Jakarta',
+  location_text text,
+  location_url text,
+  is_online boolean not null default false,
+  capacity integer check (capacity is null or capacity > 0),
+  cover_url text,
+  contact_method text not null default 'whatsapp'
+    check (contact_method in ('whatsapp', 'instagram', 'discord')),
+  visibility text not null default 'public'
+    check (visibility in ('public', 'community')),
+  status text not null default 'scheduled'
+    check (status in ('scheduled', 'cancelled', 'completed')),
+  is_hidden boolean not null default false,
+  discord_announced_at timestamptz,
+  created_at timestamptz default now() not null,
+  updated_at timestamptz default now() not null
+);
+
+create index if not exists idx_events_starts on public.events(starts_at);
+create index if not exists idx_events_host on public.events(host_id);
+create index if not exists idx_events_upcoming
+  on public.events(starts_at)
+  where is_hidden = false and status = 'scheduled';
+
+drop trigger if exists trg_events_updated_at on public.events;
+create trigger trg_events_updated_at
+  before update on public.events
+  for each row execute function public.set_updated_at();
+
+-- =============================================================================
+-- 2. event_rsvps table — composite PK gives uniqueness for free
+-- =============================================================================
+create table if not exists public.event_rsvps (
+  event_id uuid not null references public.events(id) on delete cascade,
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  status text not null default 'going'
+    check (status in ('going', 'maybe', 'declined')),
+  note text check (note is null or length(note) <= 280),
+  created_at timestamptz default now() not null,
+  primary key (event_id, profile_id)
+);
+
+create index if not exists idx_event_rsvps_event on public.event_rsvps(event_id);
+create index if not exists idx_event_rsvps_profile on public.event_rsvps(profile_id);
+
+-- =============================================================================
+-- 3. RLS — events mirror books policies; rsvps mirror saved_books
+-- =============================================================================
+alter table public.events enable row level security;
+alter table public.event_rsvps enable row level security;
+
+drop policy if exists "events_select_public" on public.events;
+create policy "events_select_public" on public.events
+  for select using (
+    is_hidden = false and (visibility = 'public' or host_id = auth.uid())
+  );
+
+drop policy if exists "events_insert_own" on public.events;
+create policy "events_insert_own" on public.events
+  for insert with check (auth.uid() = host_id);
+
+drop policy if exists "events_update_own" on public.events;
+create policy "events_update_own" on public.events
+  for update using (auth.uid() = host_id) with check (auth.uid() = host_id);
+
+drop policy if exists "events_delete_own" on public.events;
+create policy "events_delete_own" on public.events
+  for delete using (auth.uid() = host_id);
+
+drop policy if exists "event_rsvps_select_all" on public.event_rsvps;
+create policy "event_rsvps_select_all" on public.event_rsvps
+  for select using (true);
+
+drop policy if exists "event_rsvps_insert_own" on public.event_rsvps;
+create policy "event_rsvps_insert_own" on public.event_rsvps
+  for insert with check (auth.uid() = profile_id);
+
+drop policy if exists "event_rsvps_update_own" on public.event_rsvps;
+create policy "event_rsvps_update_own" on public.event_rsvps
+  for update using (auth.uid() = profile_id) with check (auth.uid() = profile_id);
+
+drop policy if exists "event_rsvps_delete_own" on public.event_rsvps;
+create policy "event_rsvps_delete_own" on public.event_rsvps
+  for delete using (auth.uid() = profile_id);
+
+-- =============================================================================
+-- 4. Activity log extension — EVENT_CREATED + EVENT_RSVPED
+-- =============================================================================
+alter table public.activity_log
+  drop constraint if exists activity_log_type_check;
+
+alter table public.activity_log
+  add constraint activity_log_type_check
+    check (type in (
+      'USER_JOINED',
+      'BOOK_ADDED',
+      'BOOK_STATUS_CHANGED',
+      'WTB_POSTED',
+      'EVENT_CREATED',
+      'EVENT_RSVPED'
+    ));
+
+alter table public.activity_log
+  add column if not exists event_id uuid
+    references public.events(id) on delete cascade;
+
+create index if not exists idx_activity_event on public.activity_log(event_id);
+
+-- Event created → EVENT_CREATED (public + non-hidden only)
+create or replace function public.emit_event_created()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  if new.is_hidden = false and new.visibility = 'public' then
+    insert into public.activity_log(actor_user_id, type, event_id, created_at)
+    values (new.host_id, 'EVENT_CREATED', new.id, new.created_at);
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_event_created on public.events;
+create trigger trg_event_created
+  after insert on public.events
+  for each row execute function public.emit_event_created();
+
+-- RSVP inserted with status='going' → EVENT_RSVPED
+-- INSERT-only; toggling maybe → going → maybe doesn't spam the feed.
+create or replace function public.emit_event_rsvped()
+returns trigger language plpgsql security definer set search_path = public as $$
+declare
+  ev public.events%rowtype;
+begin
+  select * into ev from public.events where id = new.event_id;
+  if ev.is_hidden = false and ev.visibility = 'public' and new.status = 'going' then
+    insert into public.activity_log(actor_user_id, type, event_id, metadata, created_at)
+    values (
+      new.profile_id,
+      'EVENT_RSVPED',
+      new.event_id,
+      jsonb_build_object('rsvp_status', new.status),
+      new.created_at
+    );
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_event_rsvped on public.event_rsvps;
+create trigger trg_event_rsvped
+  after insert on public.event_rsvps
+  for each row execute function public.emit_event_rsvped();
+
+-- =============================================================================
+-- 5. Comments
+-- =============================================================================
+comment on table public.events is
+  'Community events. EVENT_CREATED activity emitted on insert (public + non-hidden only). Mastermind knowledge-artifact extensions land in a later migration.';
+
+comment on table public.event_rsvps is
+  'Composite PK (event_id, profile_id) ensures one row per attendee. EVENT_RSVPED activity fires on INSERT with status=going only — re-RSVP toggles via UPDATE do not spam the feed.';

--- a/types/index.ts
+++ b/types/index.ts
@@ -268,3 +268,81 @@ export interface AdminNote {
 export interface AdminNoteWithAuthor extends AdminNote {
   author: Pick<Profile, "id" | "full_name" | "username" | "photo_url"> | null;
 }
+
+// =============================================================================
+// Events (mirrors supabase/migrations/0020_events.sql)
+// =============================================================================
+
+export type EventStatus = "scheduled" | "cancelled" | "completed";
+export type EventVisibility = "public" | "community";
+export type EventRsvpStatus = "going" | "maybe" | "declined";
+
+export interface Event {
+  id: string;
+  host_id: string;
+  community_id: string | null;
+  title: string;
+  description: string | null;
+  starts_at: string;
+  ends_at: string | null;
+  timezone: string;
+  location_text: string | null;
+  location_url: string | null;
+  is_online: boolean;
+  capacity: number | null;
+  cover_url: string | null;
+  contact_method: ContactMethod;
+  visibility: EventVisibility;
+  status: EventStatus;
+  is_hidden: boolean;
+  discord_announced_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** An Event joined with host profile + community + viewer-specific RSVP state. */
+export interface EventWithHost extends Event {
+  host: Pick<
+    Profile,
+    | "id"
+    | "full_name"
+    | "username"
+    | "photo_url"
+    | "city"
+    | "whatsapp"
+    | "whatsapp_public"
+    | "instagram"
+    | "discord"
+  >;
+  community: Pick<Community, "id" | "name" | "slug"> | null;
+  rsvp_count: number;
+  viewer_rsvp: EventRsvpStatus | null;
+}
+
+export interface EventRsvp {
+  event_id: string;
+  profile_id: string;
+  status: EventRsvpStatus;
+  note: string | null;
+  created_at: string;
+}
+
+export interface EventRsvpWithProfile extends EventRsvp {
+  profile: Pick<Profile, "id" | "full_name" | "username" | "photo_url">;
+}
+
+/** Form value types — what the Event form posts. */
+export interface EventFormValues {
+  title: string;
+  description?: string;
+  starts_at: string;
+  ends_at?: string;
+  timezone?: string;
+  location_text?: string;
+  location_url?: string;
+  is_online?: boolean;
+  capacity?: number;
+  cover_url?: string;
+  contact_method?: ContactMethod;
+  visibility?: EventVisibility;
+}


### PR DESCRIPTION
﻿## Why

The Collective Library Business Model Canvas / Phase 1 Roadmap names **events the "activation spine"** — the highest-leverage missing piece for the 1,000-user target. Most of the Phase 1 surface (activity feed, profile, marketplace, member map, Discord webhook relay, Mastermind cockpit, RSS+JSON public feeds) already ships. This PR fills the gap.

Thin vertical slice — create event, RSVP (going/maybe/cancel), surface in activity feed + landing strips, host can manually announce to Discord. Cover-image upload, recurring events, ticketing, comments, check-in, place picker, capacity enforcement, calendar export, co-hosts are all explicitly **deferred**.

## What ships

### Schema — `supabase/migrations/0020_events.sql`
- `events` table (host_id, community_id, title, description, starts_at/ends_at, timezone, location_text/url, is_online, capacity, cover_url, contact_method, visibility, status, is_hidden, `discord_announced_at`)
- `event_rsvps` table with composite PK `(event_id, profile_id)` and status enum `going|maybe|declined`
- RLS: events mirror `books` (host-owned writes, public reads); rsvps mirror `saved_books` (self-owned writes, public reads)
- `activity_log` extended with `EVENT_CREATED` + `EVENT_RSVPED` types and `event_id` FK column (cascade delete)
- `emit_event_rsvped` fires on INSERT only with `status=going` — toggling maybe→going→maybe doesn't spam the feed (matches `0018_fix_activity_spam` philosophy)

### Routes
| Path | File | Auth | Notes |
|---|---|---|---|
| `/event` | `app/(app)/event/page.tsx` | gated | upcoming/past filter pills, FAB to `/event/new` |
| `/event/new` | `app/(app)/event/new/page.tsx` | gated | 2-step create form (when+where → details) |
| `/event/[id]` | `app/(app)/event/[id]/page.tsx` | gated | hero + tabs + sticky RSVP/announce panel, `generateMetadata` for OG |
| `/event/[id]/edit` | `app/(app)/event/[id]/edit/page.tsx` | host-only | edit + soft-delete danger zone |
| `/api/events/[id]/rsvp` | `app/api/events/[id]/rsvp/route.ts` | POST | upsert with composite-PK on-conflict; `status: null` deletes |
| `/api/events/[id]/announce` | `app/api/events/[id]/announce/route.ts` | host-only | Discord embed; `DISCORD_EVENTS_WEBHOOK_URL` → fallback to `DISCORD_FEEDBACK_WEBHOOK_URL` |

### Components — `components/events/*`
- `event-card.tsx` — 16:9 cover, date pill, host avatar, RSVP count, "Online" badge
- `event-form.tsx` — 2-step client form, browser-side Supabase insert via RLS
- `rsvp-button.tsx` — 3-state optimistic toggle with `useOptimistic` + `useTransition` (React 19)
- `event-detail-tabs.tsx` — Tentang / Detail / Host / Hadir, mobile underline + desktop stacked
- `discord-announce-button.tsx` — host manual trigger, `discord_announced_at` idempotency display
- `components/landing/upcoming-events-strip.tsx` — landing strip mirroring `RecentBooksStrip`, returns `null` when 0 upcoming

### Data access & types
- `lib/events.ts` — `listEvents`, `getEvent` (with viewer_rsvp), `createEvent`, `updateEvent`, `deleteEvent`, `rsvpEvent` (upsert), `cancelRsvp`, `listEventRsvps`, `getUpcomingEvents`, `getRawEvent`
- `lib/format.ts` — `formatEventWhen` (Indonesian locale + WIB/WITA/WIT label)
- `types/index.ts` — `Event`, `EventWithHost`, `EventRsvp(WithProfile)`, `EventFormValues` + enums

### Activity feed integration
- `lib/activity.ts` — `ActivityType` extended, `ActivityItem.event` field added, events join in `SELECT`
- `activity-copy.ts` — "bikin event: …" / "bakal dateng ke: …" verbs + `/event/<id>` URL handler
- `activity-feed-list.tsx` — event render block (cover + date + title)

### Wiring
- `app/page.tsx` — `<UpcomingEventsStrip />` between RecentBooks and ActivityFeed
- `app/(app)/shelf/page.tsx` — 4-card EventCard grid above ActivityFeed, only on unfiltered page 1
- `app/feed.xml` + `app/feed.json` — handle `item.event` for permalink + cover thumbnail
- `proxy.ts` — `/event/*` added to auth-gated route list (matches `/book/[id]` pattern)
- `docs/STATE.md` — migration table bumped, "Event Management MVP ✅ shipped" backlog entry, optional `DISCORD_EVENTS_WEBHOOK_URL` row in outstanding-actions table

## Reviewer notes

- **Build**: `npm run build` exit 0. All 4 event routes + 2 API routes register.
- **Lint**: clean for every file in this PR. Pre-existing errors in `app/error.tsx`, `topbar-search.tsx`, `anggota-filter-sheet.tsx`, `location-picker.tsx`, `ui/input.tsx` are unrelated and out of scope.
- **Migration safety**: `0020_events.sql` is re-runnable — every `create policy` wrapped in `drop policy if exists`, every table/column `if not exists`. The `activity_log_type_check` constraint is replaced atomically.
- **No new dependencies.** Reuses `@supabase/ssr`, `sonner`, React 19, Tailwind v4, all existing primitives.
- **Discord webhook**: announce route reads `DISCORD_EVENTS_WEBHOOK_URL`, falls back to `DISCORD_FEEDBACK_WEBHOOK_URL` if unset. Add the env var in Vercel before merging to `main` if you want a dedicated channel.
- **Event detail visibility**: routes live inside `(app)` group, auth-gated like `/book/[id]`. Public detail (anon → LoginNudge) can be split off later, mirroring how `/profile/[username]` migrated out.
- **No protected files touched.** `app/layout.tsx`, `app/globals.css`, existing migrations are untouched. `proxy.ts` adds one entry to `isAppRoute`.

## Required before merging to `main`

1. Apply `supabase/migrations/0020_events.sql` in the Supabase SQL editor (dev project first, then prod on merge to `main`)
2. (Optional) Add `DISCORD_EVENTS_WEBHOOK_URL` to Vercel env vars

## Test plan

- [ ] Apply `0020_events.sql`; confirm `events`, `event_rsvps`, `activity_log_type_check` updated, `event_id` column on `activity_log`
- [ ] Create event as User A → lands on `/event/[id]`
- [ ] `/aktivitas` shows "A bikin event: …" at top
- [ ] `/feed.xml` includes the event with link to `/event/[id]`
- [ ] User B RSVPs "Hadir" → optimistic update → attendees tab shows B → activity feed shows "B bakal dateng ke: …"
- [ ] B toggles "Mungkin" → "Hadir" — confirm exactly **one** `EVENT_RSVPED` row in `activity_log`
- [ ] As host, click "Umumkan ke Discord" → embed lands in Discord channel → button shows "Diumumkan 0 menit lalu"
- [ ] Edit event as host → detail page reflects
- [ ] Non-host `PATCH /api/events/[id]` via curl → 0 rows updated
- [ ] Delete event → `event_rsvps` + `activity_log.event_id` rows cascade-deleted
- [ ] Anon visits `/` → upcoming-events strip appears between Recent Books and Activity (returns `null` on 0 events, so fresh deploy stays clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
