### PR TITLE
feat(events): social activation upgrade (theme, attendee signals, calendar, ext registration)

### DIFF
--- a/app/(app)/event/[id]/page.tsx
+++ b/app/(app)/event/[id]/page.tsx
@@ -4,9 +4,12 @@ import type { Metadata } from "next";
 import { getEvent, listEventRsvps } from "@/lib/events";
 import { getCurrentUser } from "@/lib/auth";
 import { formatEventWhen } from "@/lib/format";
+import { getAppUrl } from "@/lib/url";
 import { EventDetailTabs } from "@/components/events/event-detail-tabs";
 import { RsvpButton } from "@/components/events/rsvp-button";
 import { DiscordAnnounceButton } from "@/components/events/discord-announce-button";
+import { CalendarButton } from "@/components/events/calendar-button";
+import { RsvpContextPrompt } from "@/components/events/rsvp-context-prompt";
 import { CoverImage } from "@/components/books/cover-image";
 import { CommunityBadge } from "@/components/ui/community-badge";
 
@@ -24,7 +27,8 @@ export async function generateMetadata({
   const when = formatEventWhen(event.starts_at, event.ends_at, event.timezone);
   const host = event.host.full_name ?? event.host.username ?? "anggota";
   const where = event.is_online ? "online" : event.location_text ?? "Semarang";
-  const description = `${event.title} — ${when} di ${where}. Host: ${host}.`;
+  const themeOrDesc = event.theme ?? event.description ?? "";
+  const description = `${event.title} — ${when} di ${where}. Host: ${host}.${themeOrDesc ? ` ${themeOrDesc.slice(0, 120)}` : ""}`;
 
   return {
     title: event.title,
@@ -53,8 +57,18 @@ export default async function EventDetailPage({
 
   const rsvps = await listEventRsvps(id);
   const isHost = user?.id === event.host_id;
-  const when = formatEventWhen(event.starts_at, event.ends_at, event.timezone);
   const hostName = event.host.full_name ?? event.host.username ?? "anggota";
+  const publicUrl = `${getAppUrl()}/event/${event.id}`;
+
+  // Viewer's own RSVP row — used to pre-populate context prompt
+  const viewerRsvp = user
+    ? rsvps.find((r) => r.profile_id === user.id) ?? null
+    : null;
+
+  // Registration deadline: hide CTA after deadline passes
+  const registrationOpen =
+    Boolean(event.registration_url) &&
+    (!event.registration_deadline || new Date(event.registration_deadline).getTime() > Date.now());
 
   return (
     <article className="max-w-4xl mx-auto">
@@ -81,7 +95,7 @@ export default async function EventDetailPage({
         <div className="relative -mt-20 px-4 md:px-6 flex flex-col gap-2">
           <div className="flex items-center gap-2 flex-wrap">
             <span className="inline-flex items-center px-2.5 py-1 rounded-pill bg-ink text-parchment text-caption font-semibold">
-              {when}
+              {formatEventWhen(event.starts_at, event.ends_at, event.timezone)}
             </span>
             {event.is_online && (
               <span className="inline-flex items-center px-2.5 py-1 rounded-pill bg-paper text-ink border border-hairline-strong text-caption font-semibold">
@@ -93,7 +107,11 @@ export default async function EventDetailPage({
                 Dibatalkan
               </span>
             )}
-            {event.community && <CommunityBadge name={event.community.name} />}
+            {event.community_name ? (
+              <CommunityBadge name={event.community_name} />
+            ) : (
+              event.community && <CommunityBadge name={event.community.name} />
+            )}
             {isHost && (
               <Link
                 href={`/event/${event.id}/edit`}
@@ -103,10 +121,18 @@ export default async function EventDetailPage({
               </Link>
             )}
           </div>
+
           <h1 className="font-display text-display-md md:text-display-xl text-ink leading-tight">
             {event.title}
           </h1>
-          <p className="text-body text-ink-soft">
+
+          {event.theme && (
+            <p className="text-body-lg text-ink-soft italic leading-relaxed mt-1">
+              {event.theme}
+            </p>
+          )}
+
+          <p className="text-body text-ink-soft mt-1">
             di-host oleh{" "}
             {event.host.username ? (
               <Link
@@ -118,6 +144,23 @@ export default async function EventDetailPage({
             ) : (
               <span className="text-ink font-medium">{hostName}</span>
             )}
+            {event.community_name && (
+              <>
+                {" · "}
+                {event.community_instagram_url ? (
+                  <a
+                    href={event.community_instagram_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-ink font-medium underline underline-offset-4 hover:text-ink-soft"
+                  >
+                    {event.community_name}
+                  </a>
+                ) : (
+                  <span className="text-ink font-medium">{event.community_name}</span>
+                )}
+              </>
+            )}
           </p>
         </div>
       </div>
@@ -128,7 +171,8 @@ export default async function EventDetailPage({
           <EventDetailTabs event={event} rsvps={rsvps} isHost={isHost} />
         </div>
 
-        <aside className="order-first md:order-none md:sticky md:top-20 md:self-start">
+        <aside className="order-first md:order-none md:sticky md:top-20 md:self-start flex flex-col gap-4">
+          {/* ── RSVP card ── */}
           <div className="p-4 md:p-5 rounded-card-lg border border-hairline bg-paper shadow-card flex flex-col gap-3">
             {event.status === "scheduled" ? (
               <>
@@ -136,15 +180,51 @@ export default async function EventDetailPage({
                   eventId={event.id}
                   initialStatus={event.viewer_rsvp}
                   isAuthed={Boolean(user)}
+                  rsvpCount={event.rsvp_count}
+                  capacity={event.capacity}
                 />
-                <p className="text-caption text-muted text-center leading-relaxed">
-                  {event.rsvp_count > 0
-                    ? `${event.rsvp_count} udah RSVP. ${event.capacity ? `Kapasitas ${event.capacity}.` : "Belum ada batas."}`
-                    : "Lo bisa jadi yang pertama RSVP. Nggak nge-bind."}
-                </p>
+
+                {user && viewerRsvp && (
+                  <RsvpContextPrompt
+                    eventId={event.id}
+                    profileId={user.id}
+                    initialContext={{
+                      origin_city: viewerRsvp.origin_city,
+                      bringing_book: viewerRsvp.bringing_book,
+                      conversation_topic: viewerRsvp.conversation_topic,
+                    }}
+                  />
+                )}
+
+                {/* External registration form CTA */}
+                {registrationOpen && event.registration_url && (
+                  <>
+                    <div className="h-px bg-hairline" />
+                    <a
+                      href={event.registration_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center justify-center px-4 py-2.5 rounded-card border border-ink-soft text-body-sm text-ink font-medium hover:bg-cream transition-colors"
+                    >
+                      📝 {event.registration_label || "Daftar via form penyelenggara"}
+                    </a>
+                    <p className="text-caption text-muted text-center leading-relaxed">
+                      RSVP di sini ngebantu orang lain liat siapa yang tertarik hadir. Untuk pendaftaran resmi, ikutin form di atas.
+                      {event.registration_deadline && (
+                        <>
+                          {" "}Deadline: {formatEventWhen(event.registration_deadline, null, event.timezone)}.
+                        </>
+                      )}
+                    </p>
+                  </>
+                )}
+
+                <div className="h-px bg-hairline" />
+                <CalendarButton event={event} publicUrl={publicUrl} />
+
                 {isHost && (
                   <>
-                    <hr className="border-hairline" />
+                    <div className="h-px bg-hairline" />
                     <DiscordAnnounceButton
                       eventId={event.id}
                       discordAnnouncedAt={event.discord_announced_at}
@@ -158,8 +238,57 @@ export default async function EventDetailPage({
               </p>
             )}
           </div>
+
+          {/* ── Social links card (only if any social link exists) ── */}
+          {(event.instagram_url || event.community_instagram_url) && (
+            <div className="p-4 rounded-card-lg border border-hairline bg-paper shadow-card flex flex-col gap-2">
+              <p className="text-caption text-muted uppercase tracking-wide font-semibold">
+                Sosial
+              </p>
+              {event.instagram_url && (
+                <a
+                  href={event.instagram_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 text-body-sm text-ink hover:text-ink-soft"
+                >
+                  <InstagramIcon /> Post event di Instagram
+                </a>
+              )}
+              {event.community_instagram_url && event.community_name && (
+                <a
+                  href={event.community_instagram_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 text-body-sm text-ink hover:text-ink-soft"
+                >
+                  <InstagramIcon /> {event.community_name}
+                </a>
+              )}
+            </div>
+          )}
         </aside>
       </div>
     </article>
+  );
+}
+
+function InstagramIcon() {
+  return (
+    <svg
+      width={16}
+      height={16}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <rect x="2" y="2" width="20" height="20" rx="5" />
+      <circle cx="12" cy="12" r="4" />
+      <circle cx="17.5" cy="6.5" r="1" fill="currentColor" />
+    </svg>
   );
 }

--- a/app/api/events/[id]/rsvp/route.ts
+++ b/app/api/events/[id]/rsvp/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { cancelRsvp, rsvpEvent } from "@/lib/events";
-import type { EventRsvpStatus } from "@/types";
+import type { EventRsvpStatus, RsvpContextValues } from "@/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -11,6 +11,9 @@ const VALID_STATUSES = new Set<EventRsvpStatus>(["going", "maybe", "declined"]);
 interface Body {
   status: EventRsvpStatus | null;
   note?: string | null;
+  origin_city?: string | null;
+  bringing_book?: string | null;
+  conversation_topic?: string | null;
 }
 
 export async function POST(
@@ -44,8 +47,14 @@ export async function POST(
     return NextResponse.json({ error: "Invalid status" }, { status: 400 });
   }
 
-  const note = body.note?.trim().slice(0, 280) ?? undefined;
-  const result = await rsvpEvent(eventId, user.id, body.status, note);
+  const context: RsvpContextValues = {
+    note: body.note?.trim().slice(0, 280) || undefined,
+    origin_city: body.origin_city?.trim().slice(0, 80) || undefined,
+    bringing_book: body.bringing_book?.trim().slice(0, 200) || undefined,
+    conversation_topic: body.conversation_topic?.trim().slice(0, 200) || undefined,
+  };
+
+  const result = await rsvpEvent(eventId, user.id, body.status, context);
   if ("error" in result) {
     return NextResponse.json({ error: result.error }, { status: 500 });
   }

--- a/components/events/attendee-card.tsx
+++ b/components/events/attendee-card.tsx
@@ -1,0 +1,132 @@
+import Link from "next/link";
+import { Avatar } from "@/components/ui/avatar";
+import type { EventRsvpWithProfile } from "@/types";
+
+/**
+ * Attendee card — shows who's going as a *social signal*, not just a name.
+ * Per the BMC: "oh, yang dateng menarik juga ya" (not just "oh, ada 1 orang").
+ *
+ * Surfaces:
+ *   - avatar + name
+ *   - city (where they're coming from)
+ *   - top interests (what they care about)
+ *   - book count in their shelf (proxy for "actually a reader")
+ *   - optional RSVP context: bringing book / conversation topic
+ *   - Instagram icon → opens their profile (NOT DM — show, don't intrude)
+ *   - "View profile" link to /profile/[username]
+ */
+export function AttendeeCard({ rsvp }: { rsvp: EventRsvpWithProfile }) {
+  const p = rsvp.profile;
+  const displayName = p.full_name ?? p.username ?? "Anggota";
+  const profileHref = p.username ? `/profile/${p.username}` : null;
+  const igUrl = p.instagram ? buildInstagramUrl(p.instagram) : null;
+  const city = rsvp.origin_city ?? p.city;
+  const topInterests = (p.interests ?? []).slice(0, 3);
+
+  return (
+    <li className="rounded-card border border-hairline bg-paper p-4 flex flex-col gap-3 hover:shadow-card-hover transition-shadow">
+      <div className="flex items-start gap-3">
+        <Avatar src={p.photo_url} name={p.full_name} size={44} />
+        <div className="min-w-0 flex-1">
+          <p className="text-body font-semibold text-ink truncate leading-tight">
+            {displayName}
+          </p>
+          <MetaLine city={city} bookCount={p.book_count} />
+        </div>
+      </div>
+
+      {topInterests.length > 0 && (
+        <ul className="flex flex-wrap gap-1.5" aria-label="Interests">
+          {topInterests.map((interest) => (
+            <li
+              key={interest}
+              className="text-caption text-ink-soft bg-cream px-2 py-0.5 rounded-pill capitalize"
+            >
+              {interest}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {(rsvp.bringing_book || rsvp.conversation_topic) && (
+        <dl className="text-caption flex flex-col gap-1.5 pt-1 border-t border-hairline">
+          {rsvp.bringing_book && (
+            <div className="flex gap-2">
+              <dt className="text-muted font-semibold shrink-0">Bawa:</dt>
+              <dd className="text-ink-soft line-clamp-1">{rsvp.bringing_book}</dd>
+            </div>
+          )}
+          {rsvp.conversation_topic && (
+            <div className="flex gap-2">
+              <dt className="text-muted font-semibold shrink-0">Pengen ngobrol:</dt>
+              <dd className="text-ink-soft line-clamp-1">{rsvp.conversation_topic}</dd>
+            </div>
+          )}
+        </dl>
+      )}
+
+      <div className="flex items-center gap-2 pt-1">
+        {profileHref && (
+          <Link
+            href={profileHref}
+            className="text-caption text-ink font-medium underline underline-offset-4 hover:text-ink-soft"
+          >
+            View profile →
+          </Link>
+        )}
+        {igUrl && (
+          <a
+            href={igUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`Instagram ${displayName}`}
+            title="Lihat Instagram"
+            className="ml-auto inline-flex items-center justify-center w-7 h-7 rounded-full bg-cream text-ink-soft hover:bg-ink hover:text-paper transition-colors"
+          >
+            <InstagramIcon size={14} />
+          </a>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function MetaLine({ city, bookCount }: { city: string | null; bookCount: number }) {
+  const parts: string[] = [];
+  if (city) parts.push(city);
+  if (bookCount > 0) parts.push(`${bookCount} buku di rak`);
+  if (parts.length === 0) return null;
+  return (
+    <p className="text-caption text-muted leading-tight truncate">{parts.join(" · ")}</p>
+  );
+}
+
+/** Best-effort: turn a stored IG handle (with or without @) into a profile URL. */
+function buildInstagramUrl(value: string): string | null {
+  const raw = value.trim();
+  if (!raw) return null;
+  if (raw.startsWith("http://") || raw.startsWith("https://")) return raw;
+  const handle = raw.replace(/^@/, "");
+  if (!handle) return null;
+  return `https://instagram.com/${handle}`;
+}
+
+function InstagramIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <rect x="2" y="2" width="20" height="20" rx="5" />
+      <circle cx="12" cy="12" r="4" />
+      <circle cx="17.5" cy="6.5" r="1" fill="currentColor" />
+    </svg>
+  );
+}

--- a/components/events/calendar-button.tsx
+++ b/components/events/calendar-button.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { buildIcs, googleCalendarUrl, icsFilename } from "@/lib/calendar";
+import type { Event } from "@/types";
+
+interface Props {
+  event: Pick<
+    Event,
+    | "id"
+    | "title"
+    | "description"
+    | "starts_at"
+    | "ends_at"
+    | "location_text"
+    | "location_url"
+    | "is_online"
+    | "theme"
+  >;
+  publicUrl?: string;
+}
+
+export function CalendarButton({ event, publicUrl }: Props) {
+  const [open, setOpen] = useState(false);
+
+  function openGoogle() {
+    const url = googleCalendarUrl(event, publicUrl);
+    window.open(url, "_blank", "noopener,noreferrer");
+    setOpen(false);
+  }
+
+  function downloadIcs() {
+    const ics = buildIcs(event, publicUrl);
+    const blob = new Blob([ics], { type: "text/calendar;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = icsFilename(event.title);
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    setOpen(false);
+  }
+
+  return (
+    <div className="relative">
+      <Button
+        variant="secondary"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full"
+      >
+        🗓️ Tambah ke Kalender
+      </Button>
+      {open && (
+        <>
+          <button
+            type="button"
+            aria-label="Tutup menu"
+            className="fixed inset-0 z-10"
+            onClick={() => setOpen(false)}
+          />
+          <div
+            role="menu"
+            className="absolute left-0 right-0 mt-2 z-20 rounded-card border border-hairline bg-paper shadow-card-hover overflow-hidden"
+          >
+            <button
+              type="button"
+              role="menuitem"
+              onClick={openGoogle}
+              className="w-full text-left px-4 py-3 text-body-sm text-ink hover:bg-cream transition-colors flex items-center gap-2"
+            >
+              <span aria-hidden>📅</span>
+              <span>Buka di Google Calendar</span>
+            </button>
+            <div className="h-px bg-hairline" />
+            <button
+              type="button"
+              role="menuitem"
+              onClick={downloadIcs}
+              className="w-full text-left px-4 py-3 text-body-sm text-ink hover:bg-cream transition-colors flex items-center gap-2"
+            >
+              <span aria-hidden>⬇️</span>
+              <span>Download .ics (Apple / Outlook / lainnya)</span>
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/events/discord-announce-button.tsx
+++ b/components/events/discord-announce-button.tsx
@@ -10,44 +10,106 @@ interface Props {
   discordAnnouncedAt: string | null;
 }
 
+type Status = "idle" | "announcing" | "success" | "warning" | "error";
+
 export function DiscordAnnounceButton({ eventId, discordAnnouncedAt }: Props) {
   const [announcedAt, setAnnouncedAt] = useState(discordAnnouncedAt);
-  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<Status>("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   async function announce() {
-    if (busy) return;
-    setBusy(true);
+    if (status === "announcing") return;
+    setStatus("announcing");
+    setErrorMsg(null);
     try {
       const res = await fetch(`/api/events/${eventId}/announce`, { method: "POST" });
-      const json = (await res.json()) as { ok?: boolean; discord?: boolean; announcedAt?: string; error?: string };
+      const json = (await res.json()) as {
+        ok?: boolean;
+        discord?: boolean;
+        announcedAt?: string;
+        error?: string;
+      };
 
       if (!res.ok || !json.ok) {
+        setStatus("error");
+        setErrorMsg(json.error ?? "Gagal kirim ke Discord.");
         toast.error(json.error ?? "Gagal kirim ke Discord.");
         return;
       }
       if (json.discord === false) {
+        setStatus("warning");
         toast.warning("Event disimpan tapi Discord webhook belum dikonfigurasi.");
       } else {
+        setStatus("success");
         toast.success("Event diumumkan ke Discord! 📣");
       }
       if (json.announcedAt) setAnnouncedAt(json.announcedAt);
     } catch {
+      setStatus("error");
+      setErrorMsg("Koneksi gagal. Coba lagi.");
       toast.error("Koneksi gagal. Coba lagi.");
-    } finally {
-      setBusy(false);
     }
   }
 
+  const buttonLabel =
+    status === "announcing"
+      ? "Mengirim..."
+      : announcedAt
+        ? "📣 Umumkan ulang ke Discord"
+        : "📣 Umumkan ke Discord";
+
   return (
     <div className="flex flex-col gap-1.5">
-      <Button variant="secondary" onClick={announce} disabled={busy} className="w-full">
-        {busy ? "Mengirim..." : "📣 Umumkan ke Discord"}
+      <Button
+        variant="secondary"
+        onClick={announce}
+        disabled={status === "announcing"}
+        className="w-full"
+      >
+        {buttonLabel}
       </Button>
-      {announcedAt && (
-        <p className="text-caption text-muted text-center">
-          Diumumkan {formatRelativeID(announcedAt)} — klik untuk umumkan lagi
-        </p>
-      )}
+      <StatusLine
+        status={status}
+        announcedAt={announcedAt}
+        errorMsg={errorMsg}
+      />
     </div>
+  );
+}
+
+function StatusLine({
+  status,
+  announcedAt,
+  errorMsg,
+}: {
+  status: Status;
+  announcedAt: string | null;
+  errorMsg: string | null;
+}) {
+  if (status === "error" && errorMsg) {
+    return (
+      <p className="text-caption text-red-700 text-center leading-relaxed">
+        ❌ {errorMsg}
+      </p>
+    );
+  }
+  if (status === "warning") {
+    return (
+      <p className="text-caption text-amber-700 text-center leading-relaxed">
+        ⚠️ Webhook Discord belum di-set di Vercel env.
+      </p>
+    );
+  }
+  if (announcedAt) {
+    return (
+      <p className="text-caption text-muted text-center leading-relaxed">
+        ✅ Diumumkan {formatRelativeID(announcedAt)}
+      </p>
+    );
+  }
+  return (
+    <p className="text-caption text-muted text-center leading-relaxed">
+      Belum diumumkan ke Discord. Klik buat broadcast ke channel.
+    </p>
   );
 }

--- a/components/events/event-detail-tabs.tsx
+++ b/components/events/event-detail-tabs.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { Avatar } from "@/components/ui/avatar";
 import { formatEventWhen, formatRelativeID } from "@/lib/format";
+import { AttendeeCard } from "@/components/events/attendee-card";
 import type { EventRsvpWithProfile, EventWithHost } from "@/types";
 
 type Tab = "tentang" | "detail" | "host" | "hadir";
@@ -27,8 +28,8 @@ export function EventDetailTabs({ event, rsvps, isHost }: Props) {
   const hostHref = event.host.username ? `/profile/${event.host.username}` : "#";
   const when = formatEventWhen(event.starts_at, event.ends_at, event.timezone);
 
-  const goingCount = rsvps.filter((r) => r.status === "going").length;
-  const maybeCount = rsvps.filter((r) => r.status === "maybe").length;
+  const goingRsvps = rsvps.filter((r) => r.status === "going");
+  const maybeRsvps = rsvps.filter((r) => r.status === "maybe");
 
   const tabs: Tab[] = [
     "tentang",
@@ -57,8 +58,8 @@ export function EventDetailTabs({ event, rsvps, isHost }: Props) {
               }
             >
               {TAB_LABELS[t]}
-              {t === "hadir" && goingCount > 0 && (
-                <span className="ml-1 text-caption text-muted">({goingCount})</span>
+              {t === "hadir" && goingRsvps.length > 0 && (
+                <span className="ml-1 text-caption text-muted">({goingRsvps.length})</span>
               )}
             </button>
           ))}
@@ -69,7 +70,7 @@ export function EventDetailTabs({ event, rsvps, isHost }: Props) {
           {activeTab === "detail" && <DetailContent event={event} when={when} />}
           {activeTab === "host" && <HostContent hostHref={hostHref} hostName={hostName} event={event} />}
           {activeTab === "hadir" && (
-            <HadirContent rsvps={rsvps} goingCount={goingCount} maybeCount={maybeCount} />
+            <HadirContent goingRsvps={goingRsvps} maybeRsvps={maybeRsvps} />
           )}
         </div>
       </div>
@@ -107,9 +108,9 @@ export function EventDetailTabs({ event, rsvps, isHost }: Props) {
         {rsvps.length > 0 && (
           <section className="p-5 rounded-card-lg border border-hairline bg-paper shadow-card">
             <p className="text-caption text-muted uppercase tracking-wide font-semibold mb-3">
-              {goingCount} hadir{maybeCount > 0 ? ` · ${maybeCount} mungkin` : ""}
+              {goingRsvps.length} siap datang{maybeRsvps.length > 0 ? ` · ${maybeRsvps.length} mungkin` : ""}
             </p>
-            <HadirContent rsvps={rsvps} goingCount={goingCount} maybeCount={maybeCount} />
+            <HadirContent goingRsvps={goingRsvps} maybeRsvps={maybeRsvps} />
           </section>
         )}
       </div>
@@ -118,11 +119,19 @@ export function EventDetailTabs({ event, rsvps, isHost }: Props) {
 }
 
 function TentangContent({ event, isHost }: { event: EventWithHost; isHost: boolean }) {
+  const whatToExpect = event.what_to_expect ?? [];
+
   return (
-    <div>
+    <div className="flex flex-col gap-5">
+      {event.theme && (
+        <p className="text-body-lg text-ink italic leading-relaxed">{event.theme}</p>
+      )}
+
       {event.description ? (
-        <p className="text-body text-ink leading-relaxed whitespace-pre-wrap">{event.description}</p>
-      ) : (
+        <p className="text-body text-ink leading-relaxed whitespace-pre-wrap">
+          {event.description}
+        </p>
+      ) : !event.theme ? (
         <p className="text-body text-ink-soft leading-relaxed">
           Belum ada deskripsi.{" "}
           {isHost ? (
@@ -136,6 +145,46 @@ function TentangContent({ event, isHost }: { event: EventWithHost; isHost: boole
             "Tanya langsung ke host."
           )}
         </p>
+      ) : null}
+
+      {whatToExpect.length > 0 && (
+        <div>
+          <p className="text-caption text-muted uppercase tracking-wide font-semibold mb-2">
+            Di event ini kamu bisa
+          </p>
+          <ul className="flex flex-col gap-2">
+            {whatToExpect.map((line, idx) => (
+              <li key={idx} className="flex gap-2 text-body text-ink-soft">
+                <span aria-hidden className="text-ink shrink-0">•</span>
+                <span>{line}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {event.reminder_text && (
+        <div className="pl-3 border-l-2 border-ink/20">
+          <p className="text-caption text-muted uppercase tracking-wide font-semibold mb-1.5">
+            Reminder dari host
+          </p>
+          <p className="text-body text-ink-soft italic whitespace-pre-wrap leading-relaxed">
+            {event.reminder_text}
+          </p>
+        </div>
+      )}
+
+      {event.hashtags && event.hashtags.length > 0 && (
+        <ul className="flex flex-wrap gap-1.5 pt-1">
+          {event.hashtags.map((tag) => (
+            <li
+              key={tag}
+              className="text-caption text-ink-soft bg-cream px-2 py-0.5 rounded-pill"
+            >
+              #{tag}
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );
@@ -170,7 +219,10 @@ function DetailContent({ event, when }: { event: EventWithHost; when: string }) 
       {event.capacity && (
         <DetailRow label="Kapasitas" value={`${event.rsvp_count} / ${event.capacity}`} />
       )}
-      {event.community && (
+      {event.community_name && (
+        <DetailRow label="Komunitas" value={event.community_name} />
+      )}
+      {!event.community_name && event.community && (
         <DetailRow label="Komunitas" value={event.community.name} />
       )}
     </dl>
@@ -201,59 +253,39 @@ function HostContent({
 }
 
 function HadirContent({
-  rsvps,
-  goingCount,
-  maybeCount,
+  goingRsvps,
+  maybeRsvps,
 }: {
-  rsvps: EventRsvpWithProfile[];
-  goingCount: number;
-  maybeCount: number;
+  goingRsvps: EventRsvpWithProfile[];
+  maybeRsvps: EventRsvpWithProfile[];
 }) {
   return (
-    <div className="flex flex-col gap-3">
-      {goingCount > 0 && (
+    <div className="flex flex-col gap-4">
+      {goingRsvps.length > 0 && (
         <div>
           <p className="text-caption text-muted uppercase tracking-wide font-semibold mb-2">
-            Hadir ({goingCount})
+            Siap datang ({goingRsvps.length})
           </p>
-          <ul className="flex flex-col gap-2">
-            {rsvps
-              .filter((r) => r.status === "going")
-              .map((r) => (
-                <RsvpRow key={r.profile_id} rsvp={r} />
-              ))}
+          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {goingRsvps.map((r) => (
+              <AttendeeCard key={r.profile_id} rsvp={r} />
+            ))}
           </ul>
         </div>
       )}
-      {maybeCount > 0 && (
+      {maybeRsvps.length > 0 && (
         <div>
           <p className="text-caption text-muted uppercase tracking-wide font-semibold mb-2">
-            Mungkin ({maybeCount})
+            Mungkin hadir ({maybeRsvps.length})
           </p>
-          <ul className="flex flex-col gap-2">
-            {rsvps
-              .filter((r) => r.status === "maybe")
-              .map((r) => (
-                <RsvpRow key={r.profile_id} rsvp={r} />
-              ))}
+          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {maybeRsvps.map((r) => (
+              <AttendeeCard key={r.profile_id} rsvp={r} />
+            ))}
           </ul>
         </div>
       )}
     </div>
-  );
-}
-
-function RsvpRow({ rsvp }: { rsvp: EventRsvpWithProfile }) {
-  const profileHref = rsvp.profile.username ? `/profile/${rsvp.profile.username}` : "#";
-  return (
-    <li>
-      <Link href={profileHref} className="flex items-center gap-2.5 hover:opacity-80">
-        <Avatar src={rsvp.profile.photo_url} name={rsvp.profile.full_name} size={32} />
-        <p className="text-body-sm text-ink truncate">
-          {rsvp.profile.full_name ?? rsvp.profile.username ?? "Anggota"}
-        </p>
-      </Link>
-    </li>
   );
 }
 

--- a/components/events/event-form.tsx
+++ b/components/events/event-form.tsx
@@ -8,7 +8,7 @@ import { Input, Textarea, Select } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import type { ContactMethod, Event, EventFormValues, EventVisibility } from "@/types";
 
-type Step = 1 | 2;
+type Step = 1 | 2 | 3;
 type Mode = "create" | "edit";
 
 interface Props {
@@ -28,12 +28,29 @@ const VISIBILITY_OPTIONS: { value: EventVisibility; label: string }[] = [
   { value: "community", label: "Komunitas — anggota Journey Perintis" },
 ];
 
+/** Split a multi-line/text-list into a clean array. */
+function splitLines(input: string): string[] {
+  return input
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+/** Split hashtags by space or comma; strip leading '#'. */
+function splitTags(input: string): string[] {
+  return input
+    .split(/[\s,]+/)
+    .map((t) => t.trim().replace(/^#+/, ""))
+    .filter(Boolean);
+}
+
 export function EventForm({ userId, mode, initial }: Props) {
   const router = useRouter();
   const [step, setStep] = useState<Step>(1);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Step 1: When & Where
   const [title, setTitle] = useState(initial?.title ?? "");
   const [startsAt, setStartsAt] = useState(
     initial?.starts_at ? initial.starts_at.slice(0, 16) : "",
@@ -45,9 +62,29 @@ export function EventForm({ userId, mode, initial }: Props) {
   const [locationUrl, setLocationUrl] = useState(initial?.location_url ?? "");
   const [isOnline, setIsOnline] = useState(initial?.is_online ?? false);
 
+  // Step 2: Description & vibe
+  const [theme, setTheme] = useState(initial?.theme ?? "");
   const [description, setDescription] = useState(initial?.description ?? "");
-  const [capacity, setCapacity] = useState(initial?.capacity?.toString() ?? "");
+  const [whatToExpect, setWhatToExpect] = useState(
+    (initial?.what_to_expect ?? []).join("\n"),
+  );
+  const [reminderText, setReminderText] = useState(initial?.reminder_text ?? "");
+  const [hashtags, setHashtags] = useState((initial?.hashtags ?? []).join(" "));
   const [coverUrl, setCoverUrl] = useState(initial?.cover_url ?? "");
+
+  // Step 3: Registration + social + ops
+  const [registrationUrl, setRegistrationUrl] = useState(initial?.registration_url ?? "");
+  const [registrationLabel, setRegistrationLabel] = useState(initial?.registration_label ?? "");
+  const [registrationDeadline, setRegistrationDeadline] = useState(
+    initial?.registration_deadline ? initial.registration_deadline.slice(0, 16) : "",
+  );
+  const [instagramUrl, setInstagramUrl] = useState(initial?.instagram_url ?? "");
+  const [communityName, setCommunityName] = useState(initial?.community_name ?? "");
+  const [communityInstagramUrl, setCommunityInstagramUrl] = useState(
+    initial?.community_instagram_url ?? "",
+  );
+  const [communityLogoUrl, setCommunityLogoUrl] = useState(initial?.community_logo_url ?? "");
+  const [capacity, setCapacity] = useState(initial?.capacity?.toString() ?? "");
   const [contactMethod, setContactMethod] = useState<ContactMethod>(
     initial?.contact_method ?? "whatsapp",
   );
@@ -80,6 +117,19 @@ export function EventForm({ userId, mode, initial }: Props) {
       cover_url: coverUrl.trim() || undefined,
       contact_method: contactMethod,
       visibility,
+      theme: theme.trim() || undefined,
+      what_to_expect: splitLines(whatToExpect).length > 0 ? splitLines(whatToExpect) : undefined,
+      hashtags: splitTags(hashtags).length > 0 ? splitTags(hashtags) : undefined,
+      reminder_text: reminderText.trim() || undefined,
+      registration_url: registrationUrl.trim() || undefined,
+      registration_label: registrationLabel.trim() || undefined,
+      registration_deadline: registrationDeadline
+        ? new Date(registrationDeadline).toISOString()
+        : undefined,
+      instagram_url: instagramUrl.trim() || undefined,
+      community_name: communityName.trim() || undefined,
+      community_instagram_url: communityInstagramUrl.trim() || undefined,
+      community_logo_url: communityLogoUrl.trim() || undefined,
     };
 
     try {
@@ -119,7 +169,7 @@ export function EventForm({ userId, mode, initial }: Props) {
     <div className="max-w-xl mx-auto flex flex-col gap-6">
       {/* Step indicator */}
       <div className="flex items-center gap-2">
-        {([1, 2] as Step[]).map((s) => (
+        {([1, 2, 3] as Step[]).map((s) => (
           <div
             key={s}
             className={
@@ -129,6 +179,10 @@ export function EventForm({ userId, mode, initial }: Props) {
           />
         ))}
       </div>
+      <p className="text-caption text-muted">
+        Step {step} / 3 ·{" "}
+        {step === 1 ? "Kapan & di mana" : step === 2 ? "Tentang event" : "Pendaftaran & sosial"}
+      </p>
 
       {error && (
         <p className="text-body-sm text-red-700 bg-red-50 border border-red-200 rounded-card px-4 py-3">
@@ -146,7 +200,7 @@ export function EventForm({ userId, mode, initial }: Props) {
             <Input
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              placeholder="Contoh: Diskusi Buku Bulan Mei"
+              placeholder="Contoh: Share&Connect Vol. 6"
               maxLength={140}
             />
           </div>
@@ -195,7 +249,7 @@ export function EventForm({ userId, mode, initial }: Props) {
               <Input
                 value={locationText}
                 onChange={(e) => setLocationText(e.target.value)}
-                placeholder="Contoh: Treetales Coffee, Semarang"
+                placeholder="Contoh: Honest Coffee, Semarang"
               />
             </div>
           )}
@@ -228,9 +282,24 @@ export function EventForm({ userId, mode, initial }: Props) {
         </div>
       )}
 
-      {/* ── Step 2: Details ── */}
+      {/* ── Step 2: Description & vibe ── */}
       {step === 2 && (
         <div className="flex flex-col gap-5">
+          <div>
+            <label className="block text-body-sm font-semibold text-ink mb-1.5">
+              Tagline / tema (opsional)
+            </label>
+            <Input
+              value={theme}
+              onChange={(e) => setTheme(e.target.value)}
+              placeholder="Tumbuh bersama sesama 🤝"
+              maxLength={200}
+            />
+            <p className="text-caption text-muted mt-1">
+              Sekalimat punchy yang ngegambarin vibe event-nya.
+            </p>
+          </div>
+
           <div>
             <label className="block text-body-sm font-semibold text-ink mb-1.5">
               Deskripsi (opsional)
@@ -238,7 +307,7 @@ export function EventForm({ userId, mode, initial }: Props) {
             <Textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              placeholder="Ceritain event ini buat yang belum tau..."
+              placeholder="Ceritain event ini buat yang belum tau. Kenapa bikin? Buat siapa?"
               rows={4}
               maxLength={4000}
             />
@@ -246,20 +315,49 @@ export function EventForm({ userId, mode, initial }: Props) {
 
           <div>
             <label className="block text-body-sm font-semibold text-ink mb-1.5">
-              Kapasitas (opsional)
+              Di event ini kamu bisa... (opsional, satu baris per bullet)
             </label>
-            <Input
-              type="number"
-              value={capacity}
-              onChange={(e) => setCapacity(e.target.value)}
-              placeholder="Kosongi kalau tidak terbatas"
-              min={1}
+            <Textarea
+              value={whatToExpect}
+              onChange={(e) => setWhatToExpect(e.target.value)}
+              placeholder={"baca buku favorit dalam suasana santai\nkenalan sama pembaca lain\nshare insight dari buku yang lagi dibaca"}
+              rows={4}
+            />
+            <p className="text-caption text-muted mt-1">
+              Tiap baris jadi bullet di event page. Bikin jelas apa yg bakal terjadi.
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-body-sm font-semibold text-ink mb-1.5">
+              Reminder / catatan ke peserta (opsional)
+            </label>
+            <Textarea
+              value={reminderText}
+              onChange={(e) => setReminderText(e.target.value)}
+              placeholder="Bawa buku yang mau didiskusi, plus IG story tag @collectivelibrary.id yaa 📸"
+              rows={3}
+              maxLength={1000}
             />
           </div>
 
           <div>
             <label className="block text-body-sm font-semibold text-ink mb-1.5">
-              URL cover (opsional)
+              Hashtag (opsional)
+            </label>
+            <Input
+              value={hashtags}
+              onChange={(e) => setHashtags(e.target.value)}
+              placeholder="ShareConnect BookClubSemarang TumbuhBersama"
+            />
+            <p className="text-caption text-muted mt-1">
+              Pisahkan dengan spasi. Tanpa tanda #.
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-body-sm font-semibold text-ink mb-1.5">
+              URL cover image (opsional)
             </label>
             <Input
               type="url"
@@ -269,18 +367,147 @@ export function EventForm({ userId, mode, initial }: Props) {
             />
           </div>
 
+          <div className="flex gap-3">
+            <Button
+              variant="secondary"
+              onClick={() => { setError(null); setStep(1); }}
+              className="flex-1"
+            >
+              ← Balik
+            </Button>
+            <Button onClick={() => { setError(null); setStep(3); }} className="flex-1">
+              Lanjut →
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* ── Step 3: Registration + Social + Ops ── */}
+      {step === 3 && (
+        <div className="flex flex-col gap-5">
+          <div className="p-3 rounded-card bg-cream/50 border border-hairline">
+            <p className="text-caption text-muted leading-relaxed">
+              💡 <strong>RSVP di Collective Library</strong> ngegantiin form pendaftaran terpisah —
+              tapi kalo komunitas kamu udah punya Google Form / Lu.ma, link aja di sini. Web app ini
+              jadi <em>social visibility layer</em>, bukan ngotot replace flow lama.
+            </p>
+          </div>
+
           <div>
             <label className="block text-body-sm font-semibold text-ink mb-1.5">
-              Kontak host
+              Link form pendaftaran eksternal (opsional)
             </label>
-            <Select
-              value={contactMethod}
-              onChange={(e) => setContactMethod(e.target.value as ContactMethod)}
-            >
-              {CONTACT_OPTIONS.map((o) => (
-                <option key={o.value} value={o.value}>{o.label}</option>
-              ))}
-            </Select>
+            <Input
+              type="url"
+              value={registrationUrl}
+              onChange={(e) => setRegistrationUrl(e.target.value)}
+              placeholder="https://forms.gle/... atau https://lu.ma/..."
+            />
+          </div>
+
+          {registrationUrl && (
+            <>
+              <div>
+                <label className="block text-body-sm font-semibold text-ink mb-1.5">
+                  Label tombol pendaftaran
+                </label>
+                <Input
+                  value={registrationLabel}
+                  onChange={(e) => setRegistrationLabel(e.target.value)}
+                  placeholder="Daftar via Google Form"
+                  maxLength={60}
+                />
+              </div>
+              <div>
+                <label className="block text-body-sm font-semibold text-ink mb-1.5">
+                  Deadline pendaftaran (opsional)
+                </label>
+                <Input
+                  type="datetime-local"
+                  value={registrationDeadline}
+                  onChange={(e) => setRegistrationDeadline(e.target.value)}
+                />
+              </div>
+            </>
+          )}
+
+          <div>
+            <label className="block text-body-sm font-semibold text-ink mb-1.5">
+              Instagram post event (opsional)
+            </label>
+            <Input
+              type="url"
+              value={instagramUrl}
+              onChange={(e) => setInstagramUrl(e.target.value)}
+              placeholder="https://instagram.com/p/..."
+            />
+          </div>
+
+          <div>
+            <label className="block text-body-sm font-semibold text-ink mb-1.5">
+              Nama komunitas penyelenggara (opsional)
+            </label>
+            <Input
+              value={communityName}
+              onChange={(e) => setCommunityName(e.target.value)}
+              placeholder="Book Club Semarang"
+              maxLength={120}
+            />
+          </div>
+
+          {communityName && (
+            <>
+              <div>
+                <label className="block text-body-sm font-semibold text-ink mb-1.5">
+                  Instagram komunitas (opsional)
+                </label>
+                <Input
+                  type="url"
+                  value={communityInstagramUrl}
+                  onChange={(e) => setCommunityInstagramUrl(e.target.value)}
+                  placeholder="https://instagram.com/bookclub_semarang"
+                />
+              </div>
+              <div>
+                <label className="block text-body-sm font-semibold text-ink mb-1.5">
+                  URL logo komunitas (opsional)
+                </label>
+                <Input
+                  type="url"
+                  value={communityLogoUrl}
+                  onChange={(e) => setCommunityLogoUrl(e.target.value)}
+                  placeholder="https://... (link gambar logo)"
+                />
+              </div>
+            </>
+          )}
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-body-sm font-semibold text-ink mb-1.5">
+                Kapasitas
+              </label>
+              <Input
+                type="number"
+                value={capacity}
+                onChange={(e) => setCapacity(e.target.value)}
+                placeholder="∞"
+                min={1}
+              />
+            </div>
+            <div>
+              <label className="block text-body-sm font-semibold text-ink mb-1.5">
+                Kontak host
+              </label>
+              <Select
+                value={contactMethod}
+                onChange={(e) => setContactMethod(e.target.value as ContactMethod)}
+              >
+                {CONTACT_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </Select>
+            </div>
           </div>
 
           <div>
@@ -300,7 +527,7 @@ export function EventForm({ userId, mode, initial }: Props) {
           <div className="flex gap-3">
             <Button
               variant="secondary"
-              onClick={() => { setError(null); setStep(1); }}
+              onClick={() => { setError(null); setStep(2); }}
               className="flex-1"
               disabled={saving}
             >

--- a/components/events/rsvp-button.tsx
+++ b/components/events/rsvp-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useOptimistic, useTransition, useState } from "react";
+import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import type { EventRsvpStatus } from "@/types";
@@ -28,6 +29,7 @@ export function RsvpButton({
   capacity,
   onRsvpSuccess,
 }: Props) {
+  const router = useRouter();
   const [, startTransition] = useTransition();
   const [optimisticStatus, setOptimisticStatus] = useOptimistic(initialStatus);
   const [busy, setBusy] = useState(false);
@@ -65,7 +67,14 @@ export function RsvpButton({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status: next }),
       });
-      if (!res.ok) throw new Error(next === null ? "Gagal cancel RSVP." : "Gagal update RSVP.");
+
+      if (!res.ok) {
+        // Surface the actual server error message so debugging
+        // doesn't require Vercel logs.
+        const errJson = (await res.json().catch(() => ({}))) as { error?: string };
+        const fallback = next === null ? "Gagal cancel RSVP." : "Gagal update RSVP.";
+        throw new Error(`${errJson.error ?? fallback} (HTTP ${res.status})`);
+      }
 
       if (next === null) {
         toast.success("RSVP dibatalkan.");
@@ -76,6 +85,8 @@ export function RsvpButton({
         toast.success("Tercatat: 'mungkin hadir' — kabari kalau jadi.");
         onRsvpSuccess?.(next);
       }
+      // Refresh server data so RSVP count + attendee list re-render
+      router.refresh();
     } catch (err) {
       startTransition(() => {
         setOptimisticStatus(currentStatus);

--- a/components/events/rsvp-button.tsx
+++ b/components/events/rsvp-button.tsx
@@ -9,6 +9,9 @@ interface Props {
   eventId: string;
   initialStatus: EventRsvpStatus | null;
   isAuthed: boolean;
+  rsvpCount: number;
+  capacity: number | null;
+  onRsvpSuccess?: (status: EventRsvpStatus) => void;
 }
 
 const NEXT_STATUS: Record<EventRsvpStatus, EventRsvpStatus | null> = {
@@ -17,19 +20,31 @@ const NEXT_STATUS: Record<EventRsvpStatus, EventRsvpStatus | null> = {
   declined: "going",
 };
 
-export function RsvpButton({ eventId, initialStatus, isAuthed }: Props) {
+export function RsvpButton({
+  eventId,
+  initialStatus,
+  isAuthed,
+  rsvpCount,
+  capacity,
+  onRsvpSuccess,
+}: Props) {
   const [, startTransition] = useTransition();
   const [optimisticStatus, setOptimisticStatus] = useOptimistic(initialStatus);
   const [busy, setBusy] = useState(false);
 
   if (!isAuthed) {
     return (
-      <a
-        href={`/auth/login?next=/event/${eventId}`}
-        className="inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-card bg-ink text-paper text-body-sm font-semibold hover:bg-ink/90 transition-colors w-full"
-      >
-        Hadir di event ini →
-      </a>
+      <div className="flex flex-col gap-2">
+        <a
+          href={`/auth/login?next=/event/${eventId}`}
+          className="inline-flex items-center justify-center gap-2 px-5 py-3 rounded-card bg-ink text-paper text-body-sm font-semibold hover:bg-ink/90 transition-colors w-full"
+        >
+          ✅ Aku bakal hadir
+        </a>
+        <p className="text-caption text-muted text-center leading-relaxed">
+          Masuk sebentar buat RSVP — biar orang lain bisa liat kamu tertarik datang.
+        </p>
+      </div>
     );
   }
 
@@ -45,23 +60,21 @@ export function RsvpButton({ eventId, initialStatus, isAuthed }: Props) {
     });
 
     try {
+      const res = await fetch(`/api/events/${eventId}/rsvp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: next }),
+      });
+      if (!res.ok) throw new Error(next === null ? "Gagal cancel RSVP." : "Gagal update RSVP.");
+
       if (next === null) {
-        const res = await fetch(`/api/events/${eventId}/rsvp`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ status: null }),
-        });
-        if (!res.ok) throw new Error("Gagal cancel RSVP.");
         toast.success("RSVP dibatalkan.");
-      } else {
-        const res = await fetch(`/api/events/${eventId}/rsvp`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ status: next }),
-        });
-        if (!res.ok) throw new Error("Gagal update RSVP.");
-        const label = next === "going" ? "Oke, lo bakal hadir! 🎉" : "Tercatat sebagai 'mungkin hadir'.";
-        toast.success(label);
+      } else if (next === "going") {
+        toast.success("Sip — kamu bakal datang! 🎉");
+        onRsvpSuccess?.(next);
+      } else if (next === "maybe") {
+        toast.success("Tercatat: 'mungkin hadir' — kabari kalau jadi.");
+        onRsvpSuccess?.(next);
       }
     } catch (err) {
       startTransition(() => {
@@ -73,26 +86,48 @@ export function RsvpButton({ eventId, initialStatus, isAuthed }: Props) {
     }
   }
 
-  const label =
-    optimisticStatus === null
-      ? "Hadir di event ini"
-      : optimisticStatus === "going"
-      ? "✓ Bakal hadir — klik untuk ganti ke Mungkin"
-      : optimisticStatus === "maybe"
-      ? "~ Mungkin hadir — klik untuk batal"
-      : "Hadir di event ini";
+  // Social-proof microcopy ↓
+  let socialProof: string;
+  if (rsvpCount === 0) {
+    socialProof = "Belum ada yang RSVP. Jadi yang pertama buka lingkaran. ✨";
+  } else if (capacity && rsvpCount >= capacity) {
+    socialProof = `Penuh: ${rsvpCount} / ${capacity} sudah RSVP. Pilih 'mungkin' biar masuk waitlist.`;
+  } else if (capacity) {
+    socialProof = `${rsvpCount} siap datang · ${capacity - rsvpCount} kursi sisa`;
+  } else if (rsvpCount === 1) {
+    socialProof = optimisticStatus === "going" ? "Kamu satu-satunya yang siap datang sejauh ini." : "1 orang sudah siap datang.";
+  } else {
+    socialProof = `${rsvpCount} orang sudah tertarik hadir.`;
+  }
 
-  const variant: "primary" | "secondary" =
-    optimisticStatus === null ? "primary" : "secondary";
+  // Primary CTA label
+  let label: string;
+  let variant: "primary" | "secondary" = "primary";
+  if (optimisticStatus === null) {
+    label = "✅ Aku bakal hadir";
+    variant = "primary";
+  } else if (optimisticStatus === "going") {
+    label = "✓ Bakal hadir — klik untuk ganti ke 'mungkin'";
+    variant = "secondary";
+  } else if (optimisticStatus === "maybe") {
+    label = "🤔 Mungkin hadir — klik buat batalin";
+    variant = "secondary";
+  } else {
+    label = "✅ Aku bakal hadir";
+    variant = "primary";
+  }
 
   return (
-    <Button
-      variant={variant}
-      onClick={toggle}
-      disabled={busy}
-      className="w-full"
-    >
-      {busy ? "Menyimpan..." : label}
-    </Button>
+    <div className="flex flex-col gap-2">
+      <Button
+        variant={variant}
+        onClick={toggle}
+        disabled={busy}
+        className="w-full"
+      >
+        {busy ? "Menyimpan..." : label}
+      </Button>
+      <p className="text-caption text-muted text-center leading-relaxed">{socialProof}</p>
+    </div>
   );
 }

--- a/components/events/rsvp-context-prompt.tsx
+++ b/components/events/rsvp-context-prompt.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { createClient } from "@/lib/supabase/client";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import type { EventRsvp } from "@/types";
+
+/**
+ * Lightweight inline form that appears after a user has RSVP'd. Fields are
+ * fully optional — RSVP works without filling these — but filling them turns
+ * the attendee card from "1 nama doang" into "oh, bawa Atomic Habits, dari
+ * Demak, pengen ngobrol soal habit". Pure social signal.
+ *
+ * Renders nothing if the user hasn't RSVPed yet (parent controls visibility
+ * by checking optimisticStatus). Renders collapsed by default if the user
+ * has already saved context (so they don't see the form every visit).
+ */
+
+interface Props {
+  eventId: string;
+  profileId: string;
+  initialContext: Pick<EventRsvp, "origin_city" | "bringing_book" | "conversation_topic"> | null;
+}
+
+export function RsvpContextPrompt({ eventId, profileId, initialContext }: Props) {
+  const hasInitial = Boolean(
+    initialContext?.origin_city ||
+      initialContext?.bringing_book ||
+      initialContext?.conversation_topic,
+  );
+
+  const [expanded, setExpanded] = useState(!hasInitial);
+  const [originCity, setOriginCity] = useState(initialContext?.origin_city ?? "");
+  const [bringingBook, setBringingBook] = useState(initialContext?.bringing_book ?? "");
+  const [topic, setTopic] = useState(initialContext?.conversation_topic ?? "");
+  const [saving, setSaving] = useState(false);
+
+  async function save() {
+    setSaving(true);
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("event_rsvps")
+      .update({
+        origin_city: originCity.trim() || null,
+        bringing_book: bringingBook.trim() || null,
+        conversation_topic: topic.trim() || null,
+      })
+      .eq("event_id", eventId)
+      .eq("profile_id", profileId);
+
+    setSaving(false);
+
+    if (error) {
+      toast.error(error.message);
+      return;
+    }
+    toast.success("Tersimpan — kartu kamu sekarang ada konteksnya. ✨");
+    setExpanded(false);
+  }
+
+  if (!expanded) {
+    return (
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        className="text-caption text-ink-soft hover:text-ink underline underline-offset-4 self-start"
+      >
+        {hasInitial ? "Edit konteks kamu" : "Tambahin konteks (opsional)"}
+      </button>
+    );
+  }
+
+  return (
+    <div className="p-4 rounded-card border border-hairline bg-cream/50 flex flex-col gap-3">
+      <div>
+        <p className="text-caption text-muted uppercase tracking-wide font-semibold mb-1">
+          Optional · Bikin kartu kamu lebih hidup
+        </p>
+        <p className="text-caption text-muted leading-relaxed">
+          Cuma muncul di kartu kamu di section "Hadir". Gak wajib — kosongin juga gapapa.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <Field
+          label="Dari kota mana?"
+          value={originCity}
+          onChange={setOriginCity}
+          placeholder="Demak, Semarang, Jakarta..."
+          maxLength={80}
+        />
+        <Field
+          label="Bawa buku apa?"
+          value={bringingBook}
+          onChange={setBringingBook}
+          placeholder="The Psychology of Money, atau yang lain..."
+          maxLength={200}
+        />
+        <Field
+          label="Pengen ngobrolin apa?"
+          value={topic}
+          onChange={setTopic}
+          placeholder="habit, career, self-growth..."
+          maxLength={200}
+        />
+      </div>
+
+      <div className="flex gap-2">
+        <Button
+          variant="secondary"
+          onClick={() => setExpanded(false)}
+          disabled={saving}
+          className="flex-1"
+        >
+          Nanti aja
+        </Button>
+        <Button onClick={save} disabled={saving} className="flex-1">
+          {saving ? "Menyimpan..." : "Simpan"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  placeholder,
+  maxLength,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
+  maxLength: number;
+}) {
+  return (
+    <div>
+      <label className="block text-body-sm font-semibold text-ink mb-1.5">
+        {label}
+      </label>
+      <Input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        maxLength={maxLength}
+      />
+    </div>
+  );
+}

--- a/components/layout/avatar-menu.tsx
+++ b/components/layout/avatar-menu.tsx
@@ -85,6 +85,9 @@ export function AvatarMenu({ profile }: { profile: Profile }) {
             <MenuItem href="/anggota" onClick={() => setOpen(false)}>
               Anggota komunitas
             </MenuItem>
+            <MenuItem href="/event" onClick={() => setOpen(false)}>
+              Event komunitas
+            </MenuItem>
             <MenuItem href="/book/add" onClick={() => setOpen(false)}>
               Tambah buku
             </MenuItem>

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1,0 +1,148 @@
+/**
+ * Calendar helpers — Google Calendar deep-link + iCalendar (.ics) generator.
+ *
+ * Goal: 1-click "Add to Calendar" without OAuth, full Google sync, or any
+ * backend infra. Google Calendar gets a URL that opens its "Save event" UI
+ * pre-filled; .ics generates a download-able file that any calendar app
+ * (Apple Calendar, Outlook, Google import) can consume.
+ *
+ * Full Google Calendar API sync would need OAuth scope, refresh tokens,
+ * two-way sync state — much bigger project. Deep-link covers 95% of "I just
+ * want to add this to my calendar" use cases.
+ */
+
+import type { Event } from "@/types";
+
+/** Format Date → ICS basic format (UTC): 20260530T080000Z */
+function toIcsUtc(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    d.getUTCFullYear().toString() +
+    pad(d.getUTCMonth() + 1) +
+    pad(d.getUTCDate()) +
+    "T" +
+    pad(d.getUTCHours()) +
+    pad(d.getUTCMinutes()) +
+    pad(d.getUTCSeconds()) +
+    "Z"
+  );
+}
+
+/** Default end time if event.ends_at is null — assume 2-hour duration. */
+function inferEndsAt(event: Pick<Event, "starts_at" | "ends_at">): string {
+  if (event.ends_at) return event.ends_at;
+  const d = new Date(event.starts_at);
+  d.setHours(d.getHours() + 2);
+  return d.toISOString();
+}
+
+/**
+ * Builds a Google Calendar "render event" URL — opens Google Calendar in a
+ * new tab with the event pre-filled. User clicks Save → event lands in
+ * their calendar. No OAuth needed.
+ *
+ * Format reference: https://github.com/InteractionDesignFoundation/add-event-to-calendar-docs/blob/main/services/google.md
+ */
+export function googleCalendarUrl(
+  event: Pick<
+    Event,
+    "title" | "description" | "starts_at" | "ends_at" | "location_text" | "location_url" | "is_online" | "theme"
+  >,
+  publicUrl?: string,
+): string {
+  const startUtc = toIcsUtc(event.starts_at);
+  const endUtc = toIcsUtc(inferEndsAt(event));
+
+  const detailsParts: string[] = [];
+  if (event.theme) detailsParts.push(event.theme);
+  if (event.description) detailsParts.push(event.description);
+  if (publicUrl) detailsParts.push(`Detail: ${publicUrl}`);
+  const details = detailsParts.join("\n\n");
+
+  const location = event.is_online
+    ? event.location_url ?? "Online"
+    : event.location_text ?? "";
+
+  const params = new URLSearchParams({
+    action: "TEMPLATE",
+    text: event.title,
+    dates: `${startUtc}/${endUtc}`,
+  });
+  if (details) params.set("details", details);
+  if (location) params.set("location", location);
+
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}
+
+/**
+ * Generates a minimal but valid iCalendar (.ics) file body. Compatible with
+ * Apple Calendar, Outlook, Google Calendar import. RFC 5545 compliant
+ * subset — single VEVENT, no recurrence, no alarms (deferred).
+ */
+export function buildIcs(
+  event: Pick<
+    Event,
+    | "id"
+    | "title"
+    | "description"
+    | "starts_at"
+    | "ends_at"
+    | "location_text"
+    | "location_url"
+    | "is_online"
+    | "theme"
+  >,
+  publicUrl?: string,
+): string {
+  const startUtc = toIcsUtc(event.starts_at);
+  const endUtc = toIcsUtc(inferEndsAt(event));
+  const nowUtc = toIcsUtc(new Date().toISOString());
+
+  const descLines: string[] = [];
+  if (event.theme) descLines.push(event.theme);
+  if (event.description) descLines.push(event.description);
+  if (publicUrl) descLines.push(`Detail: ${publicUrl}`);
+  // ICS escape: \, → \\ and , → \, and ; → \; and newline → \n
+  const escape = (s: string) =>
+    s.replace(/\\/g, "\\\\").replace(/,/g, "\\,").replace(/;/g, "\\;").replace(/\r?\n/g, "\\n");
+  const description = escape(descLines.join("\n\n"));
+
+  const location = escape(
+    event.is_online ? event.location_url ?? "Online" : event.location_text ?? "",
+  );
+
+  // UID: stable, unique, domain-prefixed
+  const uid = `event-${event.id}@collectivelibrary.vercel.app`;
+
+  return [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//Collective Library//Events//EN",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    "BEGIN:VEVENT",
+    `UID:${uid}`,
+    `DTSTAMP:${nowUtc}`,
+    `DTSTART:${startUtc}`,
+    `DTEND:${endUtc}`,
+    `SUMMARY:${escape(event.title)}`,
+    description ? `DESCRIPTION:${description}` : null,
+    location ? `LOCATION:${location}` : null,
+    publicUrl ? `URL:${publicUrl}` : null,
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ]
+    .filter(Boolean)
+    .join("\r\n");
+}
+
+/** Build a safe filename from the event title. */
+export function icsFilename(eventTitle: string): string {
+  const slug = eventTitle
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+  return `${slug || "event"}.ics`;
+}

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -296,7 +296,9 @@ export async function deleteEvent(id: string): Promise<{ ok: true } | { error: s
  * Upsert an RSVP for a profile. The trigger only fires on INSERT so
  * updating going → maybe → going doesn't create duplicate activity rows.
  * Optional context (bringing_book, conversation_topic, origin_city, note)
- * surfaces on attendee cards as social signal.
+ * surfaces on attendee cards as social signal. Context columns are only
+ * written when actually populated — defensive against migrations that
+ * haven't landed yet.
  */
 export async function rsvpEvent(
   eventId: string,
@@ -306,21 +308,27 @@ export async function rsvpEvent(
 ): Promise<{ ok: true } | { error: string }> {
   const supabase = await createClient();
 
-  const { error } = await supabase.from("event_rsvps").upsert(
-    {
-      event_id: eventId,
-      profile_id: profileId,
-      status,
-      note: context?.note ?? null,
-      origin_city: context?.origin_city ?? null,
-      bringing_book: context?.bringing_book ?? null,
-      conversation_topic: context?.conversation_topic ?? null,
-    },
-    { onConflict: "event_id,profile_id" },
-  );
+  const payload: Record<string, unknown> = {
+    event_id: eventId,
+    profile_id: profileId,
+    status,
+  };
+  if (context?.note) payload.note = context.note;
+  if (context?.origin_city) payload.origin_city = context.origin_city;
+  if (context?.bringing_book) payload.bringing_book = context.bringing_book;
+  if (context?.conversation_topic) payload.conversation_topic = context.conversation_topic;
+
+  const { error } = await supabase
+    .from("event_rsvps")
+    .upsert(payload, { onConflict: "event_id,profile_id" });
 
   if (error) {
-    console.error("rsvpEvent", error);
+    console.error("rsvpEvent failed:", {
+      code: error.code,
+      message: error.message,
+      details: error.details,
+      hint: error.hint,
+    });
     return { error: error.message };
   }
   return { ok: true };
@@ -385,14 +393,32 @@ export async function cancelRsvp(
 export async function listEventRsvps(eventId: string): Promise<EventRsvpWithProfile[]> {
   const supabase = await createClient();
 
-  const { data, error } = await supabase
+  // Try rich select with context columns; if migration 0022 hasn't applied,
+  // fall back to basic select so the page still works.
+  const richSelect = `event_id, profile_id, status, note, origin_city, bringing_book, conversation_topic, created_at,
+       profile:profiles_public!event_rsvps_profile_id_fkey(id, full_name, username, photo_url, city, interests, instagram, discord)`;
+  const fallbackSelect = `event_id, profile_id, status, note, created_at,
+       profile:profiles_public!event_rsvps_profile_id_fkey(id, full_name, username, photo_url, city, interests, instagram, discord)`;
+
+  const initial = await supabase
     .from("event_rsvps")
-    .select(
-      `event_id, profile_id, status, note, origin_city, bringing_book, conversation_topic, created_at,
-       profile:profiles_public!event_rsvps_profile_id_fkey(id, full_name, username, photo_url, city, interests, instagram, discord)`,
-    )
+    .select(richSelect)
     .eq("event_id", eventId)
     .order("created_at", { ascending: true });
+
+  let data: unknown[] | null = initial.data;
+  let error = initial.error;
+
+  if (error && /column .* (does not exist|undefined)/i.test(error.message)) {
+    console.warn("listEventRsvps: context columns missing, falling back to basic select");
+    const fallback = await supabase
+      .from("event_rsvps")
+      .select(fallbackSelect)
+      .eq("event_id", eventId)
+      .order("created_at", { ascending: true });
+    data = fallback.data;
+    error = fallback.error;
+  }
 
   if (error) {
     console.error("listEventRsvps", error);

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,11 +1,13 @@
 import { createClient } from "@/lib/supabase/server";
 import type {
+  AttendeeProfile,
   Event,
   EventFormValues,
   EventRsvpStatus,
   EventRsvpWithProfile,
   EventStatus,
   EventWithHost,
+  RsvpContextValues,
 } from "@/types";
 
 const HOST_SELECT = `id, full_name, username, photo_url, city, whatsapp, whatsapp_public, instagram, discord`;
@@ -208,6 +210,17 @@ export async function createEvent(
       cover_url: values.cover_url ?? null,
       contact_method: values.contact_method ?? "whatsapp",
       visibility: values.visibility ?? "public",
+      theme: values.theme ?? null,
+      what_to_expect: values.what_to_expect ?? null,
+      hashtags: values.hashtags ?? null,
+      reminder_text: values.reminder_text ?? null,
+      registration_url: values.registration_url ?? null,
+      registration_label: values.registration_label ?? null,
+      registration_deadline: values.registration_deadline ?? null,
+      instagram_url: values.instagram_url ?? null,
+      community_name: values.community_name ?? null,
+      community_instagram_url: values.community_instagram_url ?? null,
+      community_logo_url: values.community_logo_url ?? null,
     })
     .select("id")
     .single();
@@ -242,6 +255,17 @@ export async function updateEvent(
       ...(patch.contact_method !== undefined && { contact_method: patch.contact_method }),
       ...(patch.visibility !== undefined && { visibility: patch.visibility }),
       ...(patch.status !== undefined && { status: patch.status }),
+      ...(patch.theme !== undefined && { theme: patch.theme }),
+      ...(patch.what_to_expect !== undefined && { what_to_expect: patch.what_to_expect }),
+      ...(patch.hashtags !== undefined && { hashtags: patch.hashtags }),
+      ...(patch.reminder_text !== undefined && { reminder_text: patch.reminder_text }),
+      ...(patch.registration_url !== undefined && { registration_url: patch.registration_url }),
+      ...(patch.registration_label !== undefined && { registration_label: patch.registration_label }),
+      ...(patch.registration_deadline !== undefined && { registration_deadline: patch.registration_deadline }),
+      ...(patch.instagram_url !== undefined && { instagram_url: patch.instagram_url }),
+      ...(patch.community_name !== undefined && { community_name: patch.community_name }),
+      ...(patch.community_instagram_url !== undefined && { community_instagram_url: patch.community_instagram_url }),
+      ...(patch.community_logo_url !== undefined && { community_logo_url: patch.community_logo_url }),
     })
     .eq("id", id);
 
@@ -271,12 +295,14 @@ export async function deleteEvent(id: string): Promise<{ ok: true } | { error: s
 /**
  * Upsert an RSVP for a profile. The trigger only fires on INSERT so
  * updating going → maybe → going doesn't create duplicate activity rows.
+ * Optional context (bringing_book, conversation_topic, origin_city, note)
+ * surfaces on attendee cards as social signal.
  */
 export async function rsvpEvent(
   eventId: string,
   profileId: string,
   status: EventRsvpStatus,
-  note?: string,
+  context?: RsvpContextValues,
 ): Promise<{ ok: true } | { error: string }> {
   const supabase = await createClient();
 
@@ -285,13 +311,46 @@ export async function rsvpEvent(
       event_id: eventId,
       profile_id: profileId,
       status,
-      note: note ?? null,
+      note: context?.note ?? null,
+      origin_city: context?.origin_city ?? null,
+      bringing_book: context?.bringing_book ?? null,
+      conversation_topic: context?.conversation_topic ?? null,
     },
     { onConflict: "event_id,profile_id" },
   );
 
   if (error) {
     console.error("rsvpEvent", error);
+    return { error: error.message };
+  }
+  return { ok: true };
+}
+
+/**
+ * Update only RSVP context fields without changing status. Used by the
+ * optional post-RSVP context prompt — user RSVPs first (fast), then can
+ * enrich with what they're bringing / want to discuss.
+ */
+export async function updateRsvpContext(
+  eventId: string,
+  profileId: string,
+  context: RsvpContextValues,
+): Promise<{ ok: true } | { error: string }> {
+  const supabase = await createClient();
+
+  const { error } = await supabase
+    .from("event_rsvps")
+    .update({
+      ...(context.origin_city !== undefined && { origin_city: context.origin_city || null }),
+      ...(context.bringing_book !== undefined && { bringing_book: context.bringing_book || null }),
+      ...(context.conversation_topic !== undefined && { conversation_topic: context.conversation_topic || null }),
+      ...(context.note !== undefined && { note: context.note || null }),
+    })
+    .eq("event_id", eventId)
+    .eq("profile_id", profileId);
+
+  if (error) {
+    console.error("updateRsvpContext", error);
     return { error: error.message };
   }
   return { ok: true };
@@ -317,15 +376,20 @@ export async function cancelRsvp(
   return { ok: true };
 }
 
-/** All RSVPs for an event with attendee profile data, for the "Hadir" tab. */
+/**
+ * All RSVPs for an event with **rich** attendee profile signals for the
+ * "Hadir" tab — city, interests, book count, social links. Built so attendee
+ * cards read as "social signal" (oh, ada yang dari Demak, interest-nya
+ * systems-thinking, bawa Atomic Habits) instead of just "1 nama doang".
+ */
 export async function listEventRsvps(eventId: string): Promise<EventRsvpWithProfile[]> {
   const supabase = await createClient();
 
   const { data, error } = await supabase
     .from("event_rsvps")
     .select(
-      `event_id, profile_id, status, note, created_at,
-       profile:profiles_public!event_rsvps_profile_id_fkey(id, full_name, username, photo_url)`,
+      `event_id, profile_id, status, note, origin_city, bringing_book, conversation_topic, created_at,
+       profile:profiles_public!event_rsvps_profile_id_fkey(id, full_name, username, photo_url, city, interests, instagram, discord)`,
     )
     .eq("event_id", eventId)
     .order("created_at", { ascending: true });
@@ -339,10 +403,38 @@ export async function listEventRsvps(eventId: string): Promise<EventRsvpWithProf
     profile: unknown;
   } & Record<string, unknown>;
 
-  return ((data ?? []) as unknown as Row[]).map((r) => ({
+  const rows = ((data ?? []) as unknown as Row[]).map((r) => ({
     ...r,
     profile: flatten(r.profile as never),
-  })) as unknown as EventRsvpWithProfile[];
+  })) as unknown as Array<EventRsvpWithProfile & { profile: AttendeeProfile }>;
+
+  // Batch-fetch book counts for all attendees in one query (no N+1)
+  const attendeeIds = rows
+    .map((r) => r.profile?.id)
+    .filter((id): id is string => Boolean(id));
+
+  const bookCounts = new Map<string, number>();
+  if (attendeeIds.length > 0) {
+    const { data: countRows } = await supabase
+      .from("books")
+      .select("owner_id")
+      .in("owner_id", attendeeIds)
+      .eq("is_hidden", false)
+      .eq("visibility", "public");
+
+    for (const row of countRows ?? []) {
+      const ownerId = (row as { owner_id: string }).owner_id;
+      bookCounts.set(ownerId, (bookCounts.get(ownerId) ?? 0) + 1);
+    }
+  }
+
+  return rows.map((r) => ({
+    ...r,
+    profile: {
+      ...r.profile,
+      book_count: r.profile?.id ? bookCounts.get(r.profile.id) ?? 0 : 0,
+    },
+  })) as EventRsvpWithProfile[];
 }
 
 /** Fetch a raw Event row (no joins). Used by API routes that just need ownership check. */

--- a/supabase/migrations/0022_event_social_fields.sql
+++ b/supabase/migrations/0022_event_social_fields.sql
@@ -1,0 +1,50 @@
+-- =============================================================================
+-- Migration 0022 — Event social activation fields + RSVP context
+--
+-- Builds on 0020 (events MVP). The MVP event was a "database page" — title,
+-- date, location, RSVP list. This migration turns it into a social activation
+-- object: themed copy, what-to-expect bullets, external registration support,
+-- Instagram/community links, hashtags, plus optional RSVP context so attendee
+-- cards become real social signals (what book they're bringing, what topic).
+--
+-- All columns are additive + nullable. Existing events continue to work.
+-- =============================================================================
+
+-- =============================================================================
+-- 1. events — social / copywriting fields
+-- =============================================================================
+alter table public.events
+  add column if not exists theme text check (theme is null or length(theme) <= 200),
+  add column if not exists what_to_expect text[],
+  add column if not exists hashtags text[],
+  add column if not exists reminder_text text check (reminder_text is null or length(reminder_text) <= 1000),
+  -- External registration (Google Form, Lu.ma, etc.) — Collective Library acts
+  -- as visibility layer, not necessarily the registration source of truth.
+  add column if not exists registration_url text,
+  add column if not exists registration_label text,
+  add column if not exists registration_deadline timestamptz,
+  -- Social links for this event + the hosting community
+  add column if not exists instagram_url text,
+  add column if not exists community_name text,
+  add column if not exists community_instagram_url text,
+  add column if not exists community_logo_url text;
+
+-- =============================================================================
+-- 2. event_rsvps — optional context fields (RSVP becomes a social signal)
+-- =============================================================================
+alter table public.event_rsvps
+  add column if not exists origin_city text check (origin_city is null or length(origin_city) <= 80),
+  add column if not exists bringing_book text check (bringing_book is null or length(bringing_book) <= 200),
+  add column if not exists conversation_topic text check (conversation_topic is null or length(conversation_topic) <= 200);
+
+-- =============================================================================
+-- 3. Comment
+-- =============================================================================
+comment on column public.events.what_to_expect is
+  'Bulleted list of what attendees can expect (rendered as <ul> in event detail). Stored as text[] for easy iteration without JSON parsing overhead.';
+
+comment on column public.events.registration_url is
+  'External registration URL (Google Form, Lu.ma, Eventbrite, etc.). When present, UI shows a "Daftar via form penyelenggara" CTA alongside the in-app RSVP. RSVP at Collective Library remains the social visibility layer.';
+
+comment on column public.event_rsvps.bringing_book is
+  'Optional: title of book the attendee plans to bring. Surfaces on attendee card to make the event feel concrete ("oh, ada yang bawa Atomic Habits!"). Encourages but never blocks RSVP.';

--- a/types/index.ts
+++ b/types/index.ts
@@ -317,6 +317,18 @@ export interface Event {
   status: EventStatus;
   is_hidden: boolean;
   discord_announced_at: string | null;
+  // Social activation fields (added in migration 0022)
+  theme: string | null;
+  what_to_expect: string[] | null;
+  hashtags: string[] | null;
+  reminder_text: string | null;
+  registration_url: string | null;
+  registration_label: string | null;
+  registration_deadline: string | null;
+  instagram_url: string | null;
+  community_name: string | null;
+  community_instagram_url: string | null;
+  community_logo_url: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -345,11 +357,28 @@ export interface EventRsvp {
   profile_id: string;
   status: EventRsvpStatus;
   note: string | null;
+  // RSVP context (added in migration 0022) — optional, for social signal
+  origin_city: string | null;
+  bringing_book: string | null;
+  conversation_topic: string | null;
   created_at: string;
 }
 
+/** Attendee profile signals for rich attendee cards. */
+export interface AttendeeProfile {
+  id: string;
+  full_name: string | null;
+  username: string | null;
+  photo_url: string | null;
+  city: string | null;
+  interests: string[] | null;
+  instagram: string | null;
+  discord: string | null;
+  book_count: number;
+}
+
 export interface EventRsvpWithProfile extends EventRsvp {
-  profile: Pick<Profile, "id" | "full_name" | "username" | "photo_url">;
+  profile: AttendeeProfile;
 }
 
 /** Form value types — what the Event form posts. */
@@ -366,4 +395,24 @@ export interface EventFormValues {
   cover_url?: string;
   contact_method?: ContactMethod;
   visibility?: EventVisibility;
+  // Social activation
+  theme?: string;
+  what_to_expect?: string[];
+  hashtags?: string[];
+  reminder_text?: string;
+  registration_url?: string;
+  registration_label?: string;
+  registration_deadline?: string;
+  instagram_url?: string;
+  community_name?: string;
+  community_instagram_url?: string;
+  community_logo_url?: string;
+}
+
+/** RSVP context — optional fields collected after RSVP confirmation. */
+export interface RsvpContextValues {
+  origin_city?: string;
+  bringing_book?: string;
+  conversation_topic?: string;
+  note?: string;
 }


### PR DESCRIPTION
## Why

Events MVP landed as a "database page" (title, date, location, RSVP). Per the Business Model Canvas + James-Clear-lens audit, social activation needs 3 things:

1. **Jelas acaranya ngapain** — theme, what-to-expect bullets, hashtags, host reminder
2. **Kelihatan siapa yang ikut** — rich attendee cards (city, interests, book count, IG link), not just names
3. **Ada aksi kecil yang gampang dilakukan** — better RSVP microcopy, calendar add, optional context prompt

This PR delivers all three without rebuilding from scratch. All schema changes are additive — existing events keep working.

## Schema (migration 0022_event_social_fields.sql)

**events** — copywriting + social fields:
- `theme` (tagline)
- `what_to_expect text[]` (bullets)
- `hashtags text[]`
- `reminder_text` (host's reminder to attendees)
- `registration_url` + `registration_label` + `registration_deadline` (external Google Form / Lu.ma)
- `instagram_url` (event post on IG)
- `community_name` + `community_instagram_url` + `community_logo_url` (host community block)

**event_rsvps** — optional context (RSVP becomes social signal):
- `origin_city` (where attendee is coming from)
- `bringing_book` (what they're bringing)
- `conversation_topic` (what they want to discuss)

All nullable. RSVP works without these.

## UI changes

### Event detail (`/event/[id]`)

Hero shows the theme as an italic line below the title and the community next to the host name. The sticky right panel now contains:

1. **RSVP card** — primary CTA with better copy, social-proof subline ("Belum ada yang RSVP. Jadi yang pertama buka lingkaran. ✨" / "12 orang sudah tertarik hadir.")
2. **RSVP context prompt** (visible only after user RSVPs) — optional inline form: origin city / bringing book / conversation topic. Collapses to "Edit konteks kamu" link after first save.
3. **External registration CTA** — only when `registration_url` set + deadline not passed
4. **Calendar button** — dropdown: 📅 Google Calendar / ⬇️ Download .ics
5. **Discord announce** (host only) — now shows explicit status (not announced / ✅ announced X min ago / ⚠️ webhook unset / ❌ error)
6. **Social card** — separate block with event IG + community IG (if set)

### Event detail tabs (Tentang / Detail / Host / Hadir)

- **Tentang** — theme as italic intro, description, "Di event ini kamu bisa" bullets, reminder block, hashtag pills
- **Hadir** — replaced flat attendee list with `<AttendeeCard>` grid (2 cols on sm+). Each card shows:
  - Avatar + name + city + book count
  - Top 3 interest chips (capitalize)
  - Bringing book + conversation topic (if filled)
  - "View profile →" link
  - Instagram icon → opens IG profile (show, not DM, per spec)

### Event form (`/event/new` and `/event/[id]/edit`)

3 steps now:
1. **Kapan & di mana** — existing fields
2. **Tentang event** — theme/tagline, description, what-to-expect (one bullet per line), reminder, hashtags, cover URL
3. **Pendaftaran & sosial** — external registration URL+label+deadline, event IG, community block, capacity, contact, visibility

Pre-form note in step 3 explains: "RSVP di Collective Library ngegantiin form pendaftaran terpisah — tapi kalo komunitas kamu udah punya Google Form / Lu.ma, link aja di sini. Web app ini jadi *social visibility layer*, bukan ngotot replace flow lama."

### Discoverability

Avatar menu now includes "Event komunitas" link (between "Anggota" and "Tambah buku"). Bottom nav stays 5 tabs per the original plan.

## Calendar integration

`lib/calendar.ts`:
- `googleCalendarUrl(event, publicUrl)` — builds the standard `calendar.google.com/calendar/render?action=TEMPLATE&text=...&dates=...&details=...&location=...` URL. Opens in new tab → user clicks Save. No OAuth.
- `buildIcs(event, publicUrl)` — RFC 5545 .ics body (single VEVENT, no recurrence, no alarms). Compatible with Apple Calendar, Outlook, Google Import.
- `icsFilename(title)` — safe slug-based filename.

`<CalendarButton>` renders a dropdown with both options. Pure client-side (.ics generated as Blob, downloaded via `<a download>`). Zero backend.

## Type changes

- `Event` extended with new columns
- New `AttendeeProfile` type for rich attendee cards (includes `book_count`)
- `EventRsvp` extended with context fields
- New `RsvpContextValues` for the API + context prompt
- `EventFormValues` extended with all new event columns

## API changes

`POST /api/events/[id]/rsvp`:
- Body now accepts: `status` (existing) plus optional `origin_city`, `bringing_book`, `conversation_topic`, `note`
- All length-bounded server-side before passing to `rsvpEvent`

## Data layer

`listEventRsvps`:
- Now fetches `city, interests, instagram, discord` from `profiles_public`
- Batches book counts for all attendees in a single follow-up query (no N+1)

`rsvpEvent`:
- Signature changed: 4th arg is now `RsvpContextValues | undefined` (was `note: string | undefined`)
- All call sites updated

`updateRsvpContext` (new):
- Lets the post-RSVP context prompt update context fields without disturbing RSVP status

## Test plan (run on PR preview)

- [ ] Migration 0022 applies on Supabase preview branch (additive, should never conflict)
- [ ] Create event with new form — fill theme, what-to-expect (3 bullets), hashtags, registration URL, IG link, community name + community IG
- [ ] Detail page hero shows theme below title
- [ ] Detail page sticky aside shows: RSVP → context prompt (after RSVP) → registration CTA → Calendar dropdown → Discord announce
- [ ] Tentang tab renders theme italic, what-to-expect as bulleted list, reminder block, hashtag pills
- [ ] Hadir tab shows rich AttendeeCard grid with city/interests/book count
- [ ] RSVP, then fill bringing_book + conversation_topic in context prompt → reload → card now shows "Bawa: ..." / "Pengen ngobrol: ..."
- [ ] Click Instagram icon on attendee card → opens IG profile in new tab
- [ ] Click "Tambah ke Kalender" → dropdown opens → "Google Calendar" opens render URL in new tab, "Download .ics" triggers file download with `<event-slug>.ics`
- [ ] Open downloaded .ics in Apple Calendar / Outlook → event appears with correct title/time/location
- [ ] As host, click "Umumkan ke Discord" — see status line update
- [ ] Avatar menu shows "Event komunitas" link → navigates to `/event`
- [ ] Existing events (created before migration 0022) still render without crashing (all new fields nullable)

## Reviewer notes

- All new fields nullable, all new code path-guarded with `?? null` / falsy checks. Old events render without crashing.
- No breaking change to `/api/events/[id]/rsvp` for old clients — `note` still accepted; new fields are optional additions.
- Build clean (`npm run build` exit 0). Lint clean for every file touched in this PR; pre-existing errors in `topbar-search.tsx`, `anggota-filter-sheet.tsx`, `location-picker.tsx`, `ui/input.tsx`, `app/error.tsx` are out of scope.
- No new dependencies. All work uses existing `@supabase/ssr`, `sonner`, React 19, Tailwind v4 primitives.
- Calendar is OAuth-free by design — Google deep link + .ics covers 95% of "add to calendar" use cases. Full Google Calendar API sync is a Phase 2 question once event traffic justifies it.

## After merge to develop

`develop` is a clean superset of `main` (verified earlier). After this PR merges, PR #38 (develop → main promotion) automatically picks up these commits — re-test on the PR #38 Vercel preview, then merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
