### PR TITLE
fix(feedback): update anonymous feedback handling for name and email …

### DIFF
--- a/components/feedback/feedback-chip.tsx
+++ b/components/feedback/feedback-chip.tsx
@@ -76,7 +76,7 @@ const CATEGORIES: { slug: FeedbackCategory; label: string; emoji: string; hint: 
 
 function FeedbackModal({ onClose }: { onClose: () => void }) {
   const [category, setCategory] = useState<FeedbackCategory>("idea");
-  const [isAnonymous, setIsAnonymous] = useState(true);
+  const [isAnonymous, setIsAnonymous] = useState<boolean | null>(null);
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [message, setMessage] = useState("");
@@ -127,7 +127,7 @@ function FeedbackModal({ onClose }: { onClose: () => void }) {
     const trimmedName = name.trim();
     const trimmedEmail = email.trim().toLowerCase();
 
-    if (isAnonymous && !trimmedName) {
+    if (isAnonymous === true && !trimmedName) {
       setError("Nama wajib diisi untuk kirim masukan.");
       return;
     }
@@ -147,8 +147,8 @@ function FeedbackModal({ onClose }: { onClose: () => void }) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           category,
-          name: isAnonymous ? trimmedName : null,
-          email: isAnonymous ? trimmedEmail || null : null,
+          name: isAnonymous === true ? trimmedName : null,
+          email: isAnonymous === true ? trimmedEmail || null : null,
           message: trimmedMessage,
           attachments: attachments.trim() || null,
           page_url:


### PR DESCRIPTION
## Summary

  Name & email fields in the "Cerita ke Kita" form no longer appear when the user is logged in. Previously, these
  fields would briefly appear then disappear due to a flash/flicker during the auth check.

  ## What changed?

  - Changed `isAnonymous` initial state from `useState(true)` to `useState<boolean | null>(null)` to indicate
  loading state
  - Updated all `isAnonymous` checks to use `isAnonymous === true` to properly handle the null case
  - Name & email fields now only render when `isAnonymous === true` (user is not logged in)

  ## Why

  When the modal opens, `isAnonymous` is immediately rendered as `true`, causing the name & email fields to appear.
  Then the `useEffect` runs to check auth status. If the user is logged in, `setIsAnonymous(false)` is called →
  fields disappear. This creates a flash/flicker that degrades UX.

  With the loading state, fields won't render until the auth status is known, eliminating the flash entirely.

  ## Scope

  - [x] Product/code

  ## Test steps

  1. Log in to the application
  2. Click the "Cerita ke Kita" button in the bottom-right corner
  3. Verify that "Nama kamu" and "Email" fields **do not appear** in the form
  4. Log out
  5. Click the "Cerita ke Kita" button again
  6. Verify that "Nama kamu" and "Email" fields **do appear** in the form
  7. Verify the form can still be submitted correctly