### PR TITLE
Fix/my feedback

### DIFF
--- a/app/(app)/feedback/page.tsx
+++ b/app/(app)/feedback/page.tsx
@@ -1,3 +1,4 @@
+import { redirect } from "next/navigation";
 import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { CATEGORY_LABELS, STATUS_LABELS } from "@/lib/feedback-constants";
@@ -26,12 +27,19 @@ export default async function ReportsPage({ searchParams }: { searchParams: Prom
 
   const supabase = await createClient();
 
-  // Main data query — RLS policy feedback_select_own filters by auth.uid() = user_id
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/auth/login");
+
+  // Main data query — filter by user_id explicitly + RLS policy
   let query = supabase
     .from("feedback")
     .select("id, category, message, status, attachments, page_url, created_at", {
       count: "exact",
     })
+    .eq("user_id", user.id)
     .order("created_at", { ascending: false });
 
   if (status !== "all") query = query.eq("status", status);
@@ -43,7 +51,7 @@ export default async function ReportsPage({ searchParams }: { searchParams: Prom
 
   const { data, error, count } = await query;
 
-  // Counts for filter pill badges (also RLS-filtered to user's own)
+  // Counts for filter pill badges (also filtered by user_id)
   const counts: Record<FeedbackStatus | "all", number> = {
     all: 0,
     new: 0,
@@ -52,7 +60,7 @@ export default async function ReportsPage({ searchParams }: { searchParams: Prom
     shipped: 0,
     wontfix: 0,
   };
-  let countsQuery = supabase.from("feedback").select("status");
+  let countsQuery = supabase.from("feedback").select("status").eq("user_id", user.id);
   if (category !== "all") countsQuery = countsQuery.eq("category", category);
   const { data: countsData } = await countsQuery;
   for (const row of countsData ?? []) {

--- a/components/layout/avatar-menu.tsx
+++ b/components/layout/avatar-menu.tsx
@@ -101,13 +101,11 @@ export function AvatarMenu({ profile }: { profile: Profile }) {
               Import from Goodreads
             </MenuItem>
           </ul>
-          {!profile.is_admin && (
-            <div className="border-t border-hairline-soft py-1.5 flex flex-col gap-1">
-              <MenuItem href="/feedback/" onClick={() => setOpen(false)}>
-                My feedback
-              </MenuItem>
-            </div>
-          )}
+          <div className="border-t border-hairline-soft py-1.5 flex flex-col gap-1">
+            <MenuItem href="/feedback/" onClick={() => setOpen(false)}>
+              My feedback
+            </MenuItem>
+          </div>
           {profile.is_admin && (
             <div className="border-t border-hairline-soft py-1.5 px-1.5 flex flex-col gap-1">
               <Link


### PR DESCRIPTION
## Summary

  - Added "My feedback" menu item for all users (including admin) in avatar menu
  - Added explicit user_id filter in `/feedback` page to ensure users only see their own feedback
  - Added auth check and redirect for unauthenticated users

  ## Why

  Users (including admins) need to track the status of feedback they've submitted. Previously:
  - Menu was hidden for admin users
  - Page relied solely on RLS policy without explicit app-layer filtering
  - No auth check before querying

  This creates a proper "My Feedback" experience with defense-in-depth: app layer filtering + RLS policy.

  ## Scope

  - [x] Product/code

  ## Test steps

  1. Login as a regular user (non-admin)
  2. Open avatar menu → click "My feedback"
  3. Verify only your own submitted feedback appears
  4. Login as admin
  5. Verify "My feedback" menu appears and shows only admin's own feedback
  6. Verify `/admin/feedback` still shows all feedback for triage