### PR TITLE
Collective Maps V1.5: fullscreen maps route

### DIFF
--- a/app/maps/page.tsx
+++ b/app/maps/page.tsx
@@ -1,0 +1,158 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { getCurrentProfile } from "@/lib/auth";
+import { isProfileComplete } from "@/types";
+import { listMembersForMap, type MapMember } from "@/lib/profile";
+import { listSpotsForMap, type SpotForMap } from "@/lib/spots";
+import { listEventsForMap, type EventForMap } from "@/lib/events";
+import { memberToMapItem, spotToMapItem, eventToMapItem } from "@/lib/map";
+import { MapsCanvasClient } from "@/components/map/maps-canvas-client";
+import { cn } from "@/lib/cn";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Collective Maps",
+  description:
+    "Peta layar penuh komunitas Collective Library — anggota, Spot baca, dan event publik di sekitar lo.",
+};
+
+type Layer = "members" | "spots" | "events";
+type SP = { layer?: Layer };
+
+export default async function MapsPage({ searchParams }: { searchParams: Promise<SP> }) {
+  // Auth + onboarding gate. /maps lives outside the (app) route group on
+  // purpose — it must NOT inherit PageShell (TopBar/BottomNav/max-width) so it
+  // can render as a true fullscreen surface. That means we replicate the gate
+  // from app/(app)/layout.tsx here. proxy.ts already gates /map* at the edge
+  // (`isAppRoute` matches the `/map` prefix, which covers `/maps`).
+  const profile = await getCurrentProfile();
+  if (!profile) redirect("/auth/login");
+  if (!isProfileComplete(profile)) redirect("/onboarding");
+
+  const { layer } = await searchParams;
+  const showMembers = !layer || layer === "members";
+  const showSpots = !layer || layer === "spots";
+  const showEvents = !layer || layer === "events";
+
+  // Fetch only the active layers, in parallel. The loaders are RLS-gated,
+  // display-safe, and fail soft (return [] on error) — an empty layer never
+  // throws the page.
+  const [members, spots, events] = await Promise.all([
+    showMembers ? listMembersForMap() : Promise.resolve<MapMember[]>([]),
+    showSpots ? listSpotsForMap() : Promise.resolve<SpotForMap[]>([]),
+    showEvents ? listEventsForMap() : Promise.resolve<EventForMap[]>([]),
+  ]);
+
+  // Reuse the existing adapters + typed union. Members stay approximate
+  // (kecamatan + jitter, applied in the canvas); Spots/events are exact
+  // public-place pins.
+  const items = [
+    ...members.map(memberToMapItem),
+    ...spots.map(spotToMapItem),
+    ...events.map(eventToMapItem),
+  ];
+  const counts = { members: members.length, spots: spots.length, events: events.length };
+  const countLine = mapsCountLine(layer, counts);
+
+  return (
+    <div className="relative h-[100dvh] w-full overflow-hidden bg-paper">
+      {/* Fullscreen map canvas (client-only — Leaflet needs window/document). */}
+      <MapsCanvasClient items={items} />
+
+      {/* Top floating chrome: back-to-app + search + layer chips.
+          pointer-events-none on the container keeps the map draggable in the
+          gaps; interactive children opt back in with pointer-events-auto.
+          z-[1000] sits above Leaflet's panes/controls. */}
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 z-[1000] flex flex-col gap-2 p-3"
+        style={{ paddingTop: "max(0.75rem, env(safe-area-inset-top))" }}
+      >
+        <div className="pointer-events-auto flex items-center gap-2">
+          <Link
+            href="/home"
+            aria-label="Balik ke app"
+            className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-pill border border-hairline-strong bg-paper/95 text-ink-soft shadow-card backdrop-blur hover:bg-cream"
+          >
+            <span aria-hidden>←</span>
+          </Link>
+          <form action="/search" className="min-w-0 flex-1">
+            <input
+              type="search"
+              name="q"
+              placeholder="Cari buku di Collective…"
+              aria-label="Cari buku"
+              className="h-10 w-full rounded-pill border border-hairline-strong bg-paper/95 px-4 text-body-sm text-ink shadow-card backdrop-blur placeholder:text-muted focus:border-ink-soft focus:outline-none"
+            />
+          </form>
+        </div>
+
+        <div className="pointer-events-auto flex gap-2 overflow-x-auto scrollbar-none">
+          <MapChip href="/maps" active={!layer} label="Semua" />
+          <MapChip href="/maps?layer=members" active={layer === "members"} label="Anggota" />
+          <MapChip href="/maps?layer=spots" active={layer === "spots"} label="Spots" />
+          <MapChip href="/maps?layer=events" active={layer === "events"} label="Event" />
+        </div>
+      </div>
+
+      {/* Bottom-left floating status + privacy card. Kept left so it clears the
+          global FeedbackChip (bottom-right). */}
+      <div
+        className="pointer-events-none absolute inset-x-0 bottom-0 z-[1000] p-3"
+        style={{ paddingBottom: "max(0.75rem, env(safe-area-inset-bottom))" }}
+      >
+        <div className="pointer-events-auto max-w-sm rounded-card-lg border border-hairline-strong bg-paper/95 p-3 shadow-card backdrop-blur">
+          <p className="text-body-sm font-medium text-ink">{countLine}</p>
+          <p className="mt-1 text-caption text-muted">
+            Pin anggota ditaruh di tengah kecamatan, bukan alamat persis. Spot &amp; event pakai
+            lokasi publik.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Status/empty copy adapted to the active layer. */
+function mapsCountLine(
+  layer: Layer | undefined,
+  c: { members: number; spots: number; events: number }
+): string {
+  if (layer === "members") {
+    return c.members === 0
+      ? "Belum ada anggota yang opt-in di peta."
+      : `${c.members} anggota tampil di peta.`;
+  }
+  if (layer === "spots") {
+    return c.spots === 0
+      ? "Belum ada Spot publik yang aktif di peta."
+      : `${c.spots} Spot aktif. Tap pin buat lihat tempat bacanya.`;
+  }
+  if (layer === "events") {
+    return c.events === 0
+      ? "Belum ada event publik mendatang di peta."
+      : `${c.events} event mendatang. Tap pin buat lihat detailnya.`;
+  }
+  const total = c.members + c.spots + c.events;
+  if (total === 0) {
+    return "Belum ada yang muncul di peta. Jadi yang pertama — tampilin lokasi lo lewat profil.";
+  }
+  return `${c.members} anggota · ${c.spots} Spot · ${c.events} event di sekitar.`;
+}
+
+function MapChip({ href, active, label }: { href: string; active: boolean; label: string }) {
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "inline-flex h-9 shrink-0 items-center rounded-pill px-4 text-body-sm font-medium shadow-card backdrop-blur transition-colors",
+        active
+          ? "bg-ink text-parchment"
+          : "border border-hairline-strong bg-paper/95 text-ink-soft hover:bg-cream"
+      )}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/components/map/collective-map-canvas.tsx
+++ b/components/map/collective-map-canvas.tsx
@@ -21,6 +21,12 @@ export interface CollectiveMapCanvasProps {
    * valid CSS length string ("100dvh", "100%") for fullscreen usage.
    */
   height?: number | string;
+  /**
+   * Show Leaflet's default +/- zoom control. Default true (preserves the /peta
+   * card). The fullscreen /maps surface passes false so its floating chrome
+   * owns the corners; the map stays zoomable via scroll wheel / pinch.
+   */
+  zoomControl?: boolean;
 }
 
 /**
@@ -35,7 +41,11 @@ export interface CollectiveMapCanvasProps {
  * peta-client.tsx already does this through map-view.tsx; future /maps will do
  * the same directly.
  */
-export function CollectiveMapCanvas({ items, height = 480 }: CollectiveMapCanvasProps) {
+export function CollectiveMapCanvas({
+  items,
+  height = 480,
+  zoomControl = true,
+}: CollectiveMapCanvasProps) {
   const view = useMemo(() => {
     if (items.length === 0) return { center: SEMARANG_CENTER, zoom: DEFAULT_ZOOM };
     if (items.length === 1) {
@@ -55,6 +65,7 @@ export function CollectiveMapCanvas({ items, height = 480 }: CollectiveMapCanvas
         zoom={view.zoom}
         style={{ height, width: "100%" }}
         scrollWheelZoom
+        zoomControl={zoomControl}
       >
         {/* Carto Positron — soft, light, parchment-friendly */}
         <TileLayer

--- a/components/map/maps-canvas-client.tsx
+++ b/components/map/maps-canvas-client.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { CollectiveMapItem } from "@/lib/map";
+
+/**
+ * Client boundary for the fullscreen `/maps` canvas.
+ *
+ * Leaflet needs window/document, so the canvas is dynamically imported with
+ * `ssr: false` (Next 16 disallows `ssr: false` in Server Components). The
+ * canvas fills its parent — the `/maps` page wraps this in a `100dvh`
+ * container — and hides Leaflet's default zoom control so the page's floating
+ * chrome owns the corners.
+ */
+const CollectiveMapCanvas = dynamic(
+  () => import("./collective-map-canvas").then((m) => m.CollectiveMapCanvas),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-full w-full items-center justify-center bg-paper text-caption text-muted">
+        Memuat peta…
+      </div>
+    ),
+  }
+);
+
+export function MapsCanvasClient({ items }: { items: CollectiveMapItem[] }) {
+  return <CollectiveMapCanvas items={items} height="100%" zoomControl={false} />;
+}


### PR DESCRIPTION
## Summary

Adds `/maps` as a new fullscreen, immersive map experience — the Collective Maps V1.5 surface. Lives **outside** the `(app)` route group so it doesn't inherit `PageShell` (TopBar / BottomNav / `max-w-6xl` container), giving a true `100dvh` canvas. `/peta` is completely untouched.

## Files changed

| File | Change |
| --- | --- |
| `app/maps/page.tsx` | **New** — fullscreen server page: auth gate, layer model (`?layer=`), data loaders, floating chrome (back link, search bar, layer chips, status + privacy card) |
| `components/map/maps-canvas-client.tsx` | **New** — client boundary (`dynamic ssr:false`) for `CollectiveMapCanvas` at `height="100%"`, `zoomControl={false}` |
| `components/map/collective-map-canvas.tsx` | **Additive** — adds optional `zoomControl?: boolean` prop (default `true`); `/peta` receives the default and is byte-identical |

## What changed

**`/maps` route:**
- Auth + onboarding gate replicates `app/(app)/layout.tsx` (needed because `/maps` is outside `(app)`; `proxy.ts` already gates `/map*` at the edge, covering `/maps`)
- `100dvh` fullscreen canvas, no max-width, no padding
- Same `?layer=members|spots|events` query model as `/peta`
- Same loaders (`listMembersForMap`, `listSpotsForMap`, `listEventsForMap`), adapters, and `CollectiveMapItem` types — no new data fetching
- Floating top chrome: `←` back-to-app, search bar (submits to `/search`), layer chips (Semua / Anggota / Spots / Event)
- Floating bottom-left status card: pin count + privacy disclaimer ("pin anggota di tengah kecamatan, bukan alamat persis; Spot & event pakai lokasi publik")
- Friendly empty states per layer
- `pointer-events-none` overlay pattern keeps the map draggable in gaps between controls

**`CollectiveMapCanvas` (additive only):**
- `zoomControl?: boolean` (default `true`) — `/peta`'s `MapView` passes no argument and is identically rendered
- `/maps` passes `zoomControl={false}` so Leaflet's ± buttons don't compete with the floating chrome in the top-right corner

## What intentionally did NOT change

- `/peta` — untouched. All existing routes, filters, chips, privacy disclaimer, member jitter, popups stay identical.
- `MapView` — untouched.
- `peta-client.tsx` — untouched.
- No new routes other than `/maps`.
- No Add button, no selected-pin bottom sheet, no Google Places/API.
- No live GPS, no book-level pins.
- No migrations, no new dependencies.

## Validation

| Check | Result |
| --- | --- |
| `tsc --noEmit` | ✅ 0 errors |
| `eslint` (3 changed files) | ✅ 0 errors |
| `npm run test` (full) | ✅ 37/37 pass |
| `npm run lint` (full) | ✅ 0 errors; 9 pre-existing warnings in unrelated files |
| `npm run build` | ✅ exit 0; `/maps` at `ƒ /maps` (dynamic); `/peta` at `ƒ /peta` unchanged |

lint-staged ran `eslint --fix --max-warnings=0` + prettier at commit time — passed.

## Manual QA checklist

- [ ] `/peta` loads unchanged — member markers, filters, privacy disclaimer intact
- [ ] `/maps` loads (auth-gated; redirects anon to login)
- [ ] `/maps` default "Semua" shows members + Spots + events
- [ ] `/maps?layer=members` — members only
- [ ] `/maps?layer=spots` — Spots only
- [ ] `/maps?layer=events` — events only
- [ ] Layer chip toggles work; active chip highlighted
- [ ] Search bar visible; submits to `/search`
- [ ] Back link (`←`) visible; returns to `/home`
- [ ] Status + privacy card visible bottom-left
- [ ] Empty-state copy is friendly when a layer has no data
- [ ] Map is draggable / scrollable (floating chrome gaps don't block interaction)
- [ ] Mobile 375px — map fills screen, controls readable, no horizontal overflow
- [ ] Desktop — controls don't overlap awkwardly
- [ ] No console errors
- [ ] No exact member addresses exposed in popups

## Privacy notes

- Member coordinates are **approximate** (kecamatan centroid + ±~250 m deterministic jitter). The `markerPosition` jitter contract is unchanged.
- Spots and events use **exact public-place coordinates** — only rows passing the `status='active' ∧ is_active ∧ visibility='public'` gate reach the map.
- Events are shown **only** when linked to a coord-bearing public Spot; online-only / private-location events are never pinned.
- All loaders are server-side, RLS-gated, and fail soft (`return []`). No service-role client on the client side.

## Follow-up (Slice D+, separate approval)

- **Slice D** — Selected-pin panel (mobile bottom sheet, desktop side panel)
- **Slice E** — Floating Add button (Tambah buku / Buat event / Edit lokasi; Spot-add TBD)
- **Slice F** — Map feedback entry point (reuse `feedback` table)
- **Slice G** — Admin map-health dashboard (`/mastermind/maps`)
- **Slice H** — Google Places admin import (V2, flag-gated, backend-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)